### PR TITLE
feat: Add CI/CD workflow YAML parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tsgit",
+  "name": "wit",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tsgit",
+      "name": "wit",
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
@@ -15,7 +15,7 @@
         "zod": "^4.2.1"
       },
       "bin": {
-        "tsgit": "dist/cli.js"
+        "wit": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/src/ci/__tests__/parser.test.ts
+++ b/src/ci/__tests__/parser.test.ts
@@ -1,0 +1,1080 @@
+/**
+ * CI/CD Workflow Parser Tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  parseWorkflow,
+  parseYAML,
+  validateWorkflow,
+  loadWorkflows,
+  loadWorkflowFile,
+  validateWorkflowFile,
+  validateExpression,
+  WorkflowValidationError,
+  WorkflowLoadError,
+  CIEngine,
+  createCIEngine,
+} from '../index';
+import { createTempDir, cleanupTempDir } from '../../__tests__/test-utils';
+
+describe('CI/CD Workflow Parser', () => {
+  describe('parseYAML', () => {
+    it('should parse simple key-value pairs', () => {
+      const yaml = `
+name: Test Workflow
+version: 1
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.name).toBe('Test Workflow');
+      expect(result.version).toBe(1);
+    });
+
+    it('should parse nested objects', () => {
+      const yaml = `
+name: Test
+on:
+  push:
+    branches:
+      - main
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.name).toBe('Test');
+      expect(result.on).toBeDefined();
+    });
+
+    it('should parse arrays', () => {
+      const yaml = `
+items:
+  - first
+  - second
+  - third
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.items).toEqual(['first', 'second', 'third']);
+    });
+
+    it('should parse booleans', () => {
+      const yaml = `
+enabled: true
+disabled: false
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.enabled).toBe(true);
+      expect(result.disabled).toBe(false);
+    });
+
+    it('should parse numbers', () => {
+      const yaml = `
+count: 42
+ratio: 3.14
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.count).toBe(42);
+      expect(result.ratio).toBe(3.14);
+    });
+
+    it('should parse quoted strings', () => {
+      const yaml = `
+single: 'hello world'
+double: "goodbye world"
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.single).toBe('hello world');
+      expect(result.double).toBe('goodbye world');
+    });
+
+    it('should skip comments', () => {
+      const yaml = `
+# This is a comment
+name: Test
+# Another comment
+version: 1
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.name).toBe('Test');
+      expect(result.version).toBe(1);
+    });
+
+    it('should parse inline arrays', () => {
+      const yaml = `
+tags: [tag1, tag2, tag3]
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.tags).toEqual(['tag1', 'tag2', 'tag3']);
+    });
+
+    it('should parse null values', () => {
+      const yaml = `
+empty: null
+tilde: ~
+`;
+      const result = parseYAML(yaml) as Record<string, unknown>;
+      expect(result.empty).toBe(null);
+      expect(result.tilde).toBe(null);
+    });
+  });
+
+  describe('parseWorkflow', () => {
+    it('should parse a valid minimal workflow', () => {
+      const yaml = `
+name: Test CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Hello"
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.name).toBe('Test CI');
+      expect(workflow.jobs.build).toBeDefined();
+      expect(workflow.jobs.build.steps).toHaveLength(1);
+    });
+
+    it('should parse workflow with multiple triggers', () => {
+      const yaml = `
+name: Multi-trigger
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+`;
+      const workflow = parseWorkflow(yaml);
+      const trigger = workflow.on as Record<string, unknown>;
+      expect(trigger.push).toBeDefined();
+      expect(trigger.pull_request).toBeDefined();
+    });
+
+    it('should parse workflow with job dependencies', () => {
+      const yaml = `
+name: With Dependencies
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm build
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: npm test
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    steps:
+      - run: npm deploy
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.jobs.build.needs).toBeUndefined();
+      expect(workflow.jobs.test.needs).toEqual(['build']);
+      expect(workflow.jobs.deploy.needs).toContain('build');
+      expect(workflow.jobs.deploy.needs).toContain('test');
+    });
+
+    it('should parse workflow with environment variables', () => {
+      const yaml = `
+name: With Env
+on:
+  push:
+env:
+  NODE_VERSION: 20
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - run: echo $NODE_VERSION
+        env:
+          DEBUG: true
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.env).toBeDefined();
+      expect(workflow.env!.NODE_VERSION).toBe(20);
+      expect(workflow.jobs.build.env!.CI).toBe(true);
+    });
+
+    it('should parse workflow with step conditions', () => {
+      const yaml = `
+name: Conditional
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only on main
+        run: echo "Main branch"
+        if: github.ref == 'refs/heads/main'
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.jobs.build.steps[0].if).toBe("github.ref == 'refs/heads/main'");
+    });
+
+    it('should parse workflow with uses action', () => {
+      const yaml = `
+name: With Actions
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.jobs.build.steps[0].uses).toBe('actions/checkout@v4');
+      expect(workflow.jobs.build.steps[1].with).toBeDefined();
+    });
+
+    it('should parse workflow with step timeout and continue-on-error', () => {
+      const yaml = `
+name: Step Options
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+        timeout-minutes: 10
+        continue-on-error: true
+`;
+      const workflow = parseWorkflow(yaml);
+      expect(workflow.jobs.build.steps[0]['timeout-minutes']).toBe(10);
+      expect(workflow.jobs.build.steps[0]['continue-on-error']).toBe(true);
+    });
+  });
+
+  describe('validateWorkflow', () => {
+    it('should throw error for missing name', () => {
+      const raw = {
+        on: { push: {} },
+        jobs: { build: { 'runs-on': 'ubuntu-latest', steps: [{ run: 'echo hi' }] } },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for missing on trigger', () => {
+      const raw = {
+        name: 'Test',
+        jobs: { build: { 'runs-on': 'ubuntu-latest', steps: [{ run: 'echo hi' }] } },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for missing jobs', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for empty jobs', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {},
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for missing runs-on', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: { steps: [{ run: 'echo hi' }] },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for missing steps', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: { 'runs-on': 'ubuntu-latest' },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for step without uses or run', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            steps: [{ name: 'Empty step' }],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for step with both uses and run', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            steps: [{ uses: 'actions/checkout@v4', run: 'echo hi' }],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for invalid trigger event', () => {
+      const raw = {
+        name: 'Test',
+        on: { invalid_event: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            steps: [{ run: 'echo hi' }],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for nonexistent job dependency', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            needs: 'nonexistent',
+            steps: [{ run: 'echo hi' }],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for self-referencing job dependency', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            needs: 'build',
+            steps: [{ run: 'echo hi' }],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should throw error for duplicate step ids', () => {
+      const raw = {
+        name: 'Test',
+        on: { push: {} },
+        jobs: {
+          build: {
+            'runs-on': 'ubuntu-latest',
+            steps: [
+              { id: 'step1', run: 'echo 1' },
+              { id: 'step1', run: 'echo 2' },
+            ],
+          },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+  });
+
+  describe('circular dependency detection', () => {
+    it('should detect simple circular dependency', () => {
+      const raw = {
+        name: 'Circular',
+        on: { push: {} },
+        jobs: {
+          a: { 'runs-on': 'ubuntu-latest', needs: 'b', steps: [{ run: 'echo a' }] },
+          b: { 'runs-on': 'ubuntu-latest', needs: 'a', steps: [{ run: 'echo b' }] },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+      try {
+        validateWorkflow(raw);
+      } catch (e) {
+        expect(e).toBeInstanceOf(WorkflowValidationError);
+        const error = e as WorkflowValidationError;
+        expect(error.errors.some(err => err.message.includes('Circular dependency'))).toBe(true);
+      }
+    });
+
+    it('should detect multi-node circular dependency', () => {
+      const raw = {
+        name: 'Circular',
+        on: { push: {} },
+        jobs: {
+          a: { 'runs-on': 'ubuntu-latest', needs: 'c', steps: [{ run: 'echo a' }] },
+          b: { 'runs-on': 'ubuntu-latest', needs: 'a', steps: [{ run: 'echo b' }] },
+          c: { 'runs-on': 'ubuntu-latest', needs: 'b', steps: [{ run: 'echo c' }] },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).toThrow(WorkflowValidationError);
+    });
+
+    it('should allow valid dependency chains', () => {
+      const raw = {
+        name: 'Valid Chain',
+        on: { push: {} },
+        jobs: {
+          a: { 'runs-on': 'ubuntu-latest', steps: [{ run: 'echo a' }] },
+          b: { 'runs-on': 'ubuntu-latest', needs: 'a', steps: [{ run: 'echo b' }] },
+          c: { 'runs-on': 'ubuntu-latest', needs: 'b', steps: [{ run: 'echo c' }] },
+          d: { 'runs-on': 'ubuntu-latest', needs: ['a', 'b', 'c'], steps: [{ run: 'echo d' }] },
+        },
+      };
+      
+      expect(() => validateWorkflow(raw)).not.toThrow();
+    });
+  });
+
+  describe('validateWorkflowFile', () => {
+    it('should return valid result for valid workflow', () => {
+      const yaml = `
+name: Valid
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`;
+      const result = validateWorkflowFile(yaml);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should return errors for invalid workflow', () => {
+      const yaml = `
+name: Invalid
+on:
+  push:
+jobs:
+`;
+      const result = validateWorkflowFile(yaml);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('validateExpression', () => {
+    it('should validate balanced parentheses', () => {
+      const expr = "${{ github.ref == 'refs/heads/main' }}";
+      const errors = validateExpression(expr);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should detect unbalanced parentheses', () => {
+      const expr = "${{ contains(github.ref, 'main' }}";
+      const errors = validateExpression(expr);
+      expect(errors.some(e => e.message.includes('parenthes'))).toBe(true);
+    });
+
+    it('should warn about empty expressions', () => {
+      const expr = '${{  }}';
+      const errors = validateExpression(expr);
+      expect(errors.some(e => e.message.includes('Empty'))).toBe(true);
+    });
+  });
+
+  describe('loadWorkflows', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tempDir);
+    });
+
+    it('should return empty array if workflows directory does not exist', () => {
+      const workflows = loadWorkflows(tempDir);
+      expect(workflows).toHaveLength(0);
+    });
+
+    it('should load workflows from .wit/workflows directory', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.mkdirSync(workflowsDir, { recursive: true });
+      
+      fs.writeFileSync(
+        path.join(workflowsDir, 'ci.yml'),
+        `
+name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      const workflows = loadWorkflows(tempDir);
+      expect(workflows).toHaveLength(1);
+      expect(workflows[0].workflow.name).toBe('CI');
+    });
+
+    it('should load multiple workflow files', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.mkdirSync(workflowsDir, { recursive: true });
+      
+      fs.writeFileSync(
+        path.join(workflowsDir, 'ci.yml'),
+        `
+name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      fs.writeFileSync(
+        path.join(workflowsDir, 'deploy.yaml'),
+        `
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+`
+      );
+      
+      const workflows = loadWorkflows(tempDir);
+      expect(workflows).toHaveLength(2);
+      expect(workflows.map(w => w.workflow.name).sort()).toEqual(['CI', 'Deploy']);
+    });
+
+    it('should ignore non-yaml files', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.mkdirSync(workflowsDir, { recursive: true });
+      
+      fs.writeFileSync(
+        path.join(workflowsDir, 'ci.yml'),
+        `
+name: CI
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      fs.writeFileSync(path.join(workflowsDir, 'readme.txt'), 'Not a workflow');
+      
+      const workflows = loadWorkflows(tempDir);
+      expect(workflows).toHaveLength(1);
+    });
+
+    it('should throw WorkflowLoadError for invalid workflow file', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.mkdirSync(workflowsDir, { recursive: true });
+      
+      fs.writeFileSync(
+        path.join(workflowsDir, 'invalid.yml'),
+        `
+name: Invalid
+# Missing on and jobs
+`
+      );
+      
+      expect(() => loadWorkflows(tempDir)).toThrow(WorkflowLoadError);
+    });
+  });
+
+  describe('loadWorkflowFile', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = createTempDir();
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tempDir);
+    });
+
+    it('should load a single workflow file', () => {
+      const filePath = path.join(tempDir, 'workflow.yml');
+      fs.writeFileSync(
+        filePath,
+        `
+name: Single
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`
+      );
+      
+      const parsed = loadWorkflowFile(filePath);
+      expect(parsed.workflow.name).toBe('Single');
+      expect(parsed.filePath).toBe(filePath);
+    });
+
+    it('should throw WorkflowLoadError for non-existent file', () => {
+      expect(() => loadWorkflowFile('/nonexistent/file.yml')).toThrow(WorkflowLoadError);
+    });
+  });
+
+  describe('CIEngine', () => {
+    let tempDir: string;
+    let engine: CIEngine;
+
+    beforeEach(() => {
+      tempDir = createTempDir();
+      engine = createCIEngine(tempDir);
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tempDir);
+    });
+
+    it('should create engine with createCIEngine', () => {
+      expect(engine).toBeInstanceOf(CIEngine);
+    });
+
+    it('should initialize workflows directory', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      expect(fs.existsSync(workflowsDir)).toBe(true);
+    });
+
+    it('should create sample workflow on init', () => {
+      engine.init();
+      const samplePath = path.join(tempDir, '.wit', 'workflows', 'ci.yml.sample');
+      expect(fs.existsSync(samplePath)).toBe(true);
+    });
+
+    it('should load workflows', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'test.yml'),
+        `
+name: Test
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+`
+      );
+      
+      const workflows = engine.load();
+      expect(workflows).toHaveLength(1);
+    });
+
+    it('should get workflow by name', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'test.yml'),
+        `
+name: Test Workflow
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+`
+      );
+      
+      engine.load();
+      const workflow = engine.getWorkflow('Test Workflow');
+      expect(workflow).toBeDefined();
+      expect(workflow!.workflow.name).toBe('Test Workflow');
+    });
+
+    it('should find matching workflows for push trigger', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'push.yml'),
+        `
+name: Push CI
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      engine.load();
+      
+      const matches = engine.findMatchingWorkflows({
+        event: 'push',
+        branch: 'main',
+      });
+      expect(matches).toHaveLength(1);
+      
+      const noMatches = engine.findMatchingWorkflows({
+        event: 'push',
+        branch: 'develop',
+      });
+      expect(noMatches).toHaveLength(0);
+    });
+
+    it('should find matching workflows for pull_request trigger', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'pr.yml'),
+        `
+name: PR CI
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+`
+      );
+      
+      engine.load();
+      
+      const matches = engine.findMatchingWorkflows({
+        event: 'pull_request',
+        branch: 'main',
+      });
+      expect(matches).toHaveLength(1);
+    });
+
+    it('should match workflow_dispatch trigger', () => {
+      engine.init();
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'manual.yml'),
+        `
+name: Manual
+on:
+  workflow_dispatch:
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo manual
+`
+      );
+      
+      engine.load();
+      
+      const matches = engine.findMatchingWorkflows({
+        event: 'workflow_dispatch',
+      });
+      expect(matches).toHaveLength(1);
+    });
+
+    it('should get job order based on dependencies', () => {
+      const yaml = `
+name: Ordered
+on:
+  push:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    steps:
+      - run: echo deploy
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+`;
+      const workflow = parseWorkflow(yaml);
+      const order = engine.getJobOrder(workflow);
+      
+      // build should come before test and deploy
+      expect(order.indexOf('build')).toBeLessThan(order.indexOf('test'));
+      expect(order.indexOf('build')).toBeLessThan(order.indexOf('deploy'));
+      // test should come before deploy
+      expect(order.indexOf('test')).toBeLessThan(order.indexOf('deploy'));
+    });
+
+    it('should get parallel jobs', () => {
+      const yaml = `
+name: Parallel
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo lint
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - run: echo test
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test
+    steps:
+      - run: echo deploy
+`;
+      const workflow = parseWorkflow(yaml);
+      
+      // Initially, build and lint can run in parallel
+      const initial = engine.getParallelJobs(workflow, new Set());
+      expect(initial).toContain('build');
+      expect(initial).toContain('lint');
+      expect(initial).not.toContain('test');
+      expect(initial).not.toContain('deploy');
+      
+      // After build completes, test can run
+      const afterBuild = engine.getParallelJobs(workflow, new Set(['build']));
+      expect(afterBuild).toContain('lint');
+      expect(afterBuild).toContain('test');
+      expect(afterBuild).not.toContain('deploy');
+      
+      // After build and test complete, deploy can run
+      const afterBuildAndTest = engine.getParallelJobs(workflow, new Set(['build', 'test']));
+      expect(afterBuildAndTest).toContain('lint');
+      expect(afterBuildAndTest).toContain('deploy');
+    });
+
+    it('should validate workflow content', () => {
+      const valid = engine.validate(`
+name: Valid
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+`);
+      expect(valid.valid).toBe(true);
+      
+      const invalid = engine.validate(`
+name: Invalid
+# missing on and jobs
+`);
+      expect(invalid.valid).toBe(false);
+    });
+  });
+
+  describe('trigger matching', () => {
+    let tempDir: string;
+    let engine: CIEngine;
+
+    beforeEach(() => {
+      tempDir = createTempDir();
+      engine = createCIEngine(tempDir);
+      engine.init();
+    });
+
+    afterEach(() => {
+      cleanupTempDir(tempDir);
+    });
+
+    it('should match glob patterns in branches', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'glob.yml'),
+        `
+name: Glob Test
+on:
+  push:
+    branches:
+      - 'feature/*'
+      - 'release/**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      engine.load();
+      
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'feature/foo' })).toHaveLength(1);
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'feature/bar/baz' })).toHaveLength(0);
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'release/v1' })).toHaveLength(1);
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'release/v1/patch' })).toHaveLength(1);
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'main' })).toHaveLength(0);
+    });
+
+    it('should respect branches-ignore', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'ignore.yml'),
+        `
+name: Ignore Test
+on:
+  push:
+    branches-ignore:
+      - 'wip/*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      engine.load();
+      
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'main' })).toHaveLength(1);
+      expect(engine.findMatchingWorkflows({ event: 'push', branch: 'wip/foo' })).toHaveLength(0);
+    });
+
+    it('should match path patterns', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'paths.yml'),
+        `
+name: Paths Test
+on:
+  push:
+    paths:
+      - 'src/**'
+      - '*.js'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+`
+      );
+      
+      engine.load();
+      
+      expect(engine.findMatchingWorkflows({ 
+        event: 'push', 
+        branch: 'main',
+        paths: ['src/index.ts'] 
+      })).toHaveLength(1);
+      
+      expect(engine.findMatchingWorkflows({ 
+        event: 'push', 
+        branch: 'main',
+        paths: ['package.json'] 
+      })).toHaveLength(0);
+    });
+
+    it('should match PR types', () => {
+      const workflowsDir = path.join(tempDir, '.wit', 'workflows');
+      fs.writeFileSync(
+        path.join(workflowsDir, 'pr-types.yml'),
+        `
+name: PR Types Test
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+`
+      );
+      
+      engine.load();
+      
+      expect(engine.findMatchingWorkflows({ 
+        event: 'pull_request', 
+        branch: 'main',
+        prType: 'opened' 
+      })).toHaveLength(1);
+      
+      expect(engine.findMatchingWorkflows({ 
+        event: 'pull_request', 
+        branch: 'main',
+        prType: 'closed' 
+      })).toHaveLength(0);
+    });
+  });
+});

--- a/src/ci/index.ts
+++ b/src/ci/index.ts
@@ -1,0 +1,464 @@
+/**
+ * CI/CD Engine Entry Point
+ * 
+ * A GitHub Actions-compatible CI/CD engine for wit repositories.
+ * Workflows are defined in .wit/workflows/*.yml
+ */
+
+// Export types
+export type {
+  Workflow,
+  WorkflowTrigger,
+  Job,
+  Step,
+  Service,
+  Container,
+  Strategy,
+  Concurrency,
+  Defaults,
+  Permissions,
+  PermissionLevel,
+  InputDef,
+  PushTrigger,
+  PullRequestTrigger,
+  ScheduleTrigger,
+  WorkflowDispatchTrigger,
+  WorkflowCallTrigger,
+  ParsedWorkflow,
+  ValidationError,
+  ValidationResult,
+  TriggerEvent,
+  ShellType,
+} from './types';
+
+export {
+  TRIGGER_EVENTS,
+  SHELL_TYPES,
+  EXPRESSION_PATTERN,
+  ACTION_REFERENCE_PATTERN,
+  CRON_PATTERN,
+} from './types';
+
+// Export parser functions
+export {
+  parseWorkflow,
+  parseYAML,
+  validateWorkflow,
+  loadWorkflows,
+  loadWorkflowFile,
+  validateWorkflowFile,
+  validateExpression,
+  WorkflowValidationError,
+  WorkflowLoadError,
+} from './parser';
+
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+  Workflow,
+  ParsedWorkflow,
+  ValidationResult,
+  TriggerEvent,
+  PushTrigger,
+  PullRequestTrigger,
+} from './types';
+import { loadWorkflows, validateWorkflowFile, WorkflowLoadError } from './parser';
+
+/**
+ * CI Engine configuration
+ */
+export interface CIEngineConfig {
+  /** Repository root path */
+  repoPath: string;
+  /** Custom workflows directory (default: .wit/workflows) */
+  workflowsDir?: string;
+  /** Enable verbose logging */
+  verbose?: boolean;
+}
+
+/**
+ * Trigger context for matching workflows
+ */
+export interface TriggerContext {
+  /** Event type */
+  event: TriggerEvent;
+  /** Branch name (for push/pull_request) */
+  branch?: string;
+  /** Tag name (for push) */
+  tag?: string;
+  /** Changed file paths */
+  paths?: string[];
+  /** Pull request type (for pull_request) */
+  prType?: string;
+  /** Workflow dispatch inputs */
+  inputs?: Record<string, string>;
+}
+
+/**
+ * CI Engine for managing and running workflows
+ */
+export class CIEngine {
+  private config: CIEngineConfig;
+  private workflows: ParsedWorkflow[] = [];
+  private loaded = false;
+  
+  constructor(config: CIEngineConfig) {
+    this.config = {
+      ...config,
+      workflowsDir: config.workflowsDir ?? path.join(config.repoPath, '.wit', 'workflows'),
+    };
+  }
+  
+  /**
+   * Load all workflows from the repository
+   */
+  load(): ParsedWorkflow[] {
+    this.workflows = loadWorkflows(this.config.repoPath);
+    this.loaded = true;
+    return this.workflows;
+  }
+  
+  /**
+   * Get all loaded workflows
+   */
+  getWorkflows(): ParsedWorkflow[] {
+    if (!this.loaded) {
+      this.load();
+    }
+    return this.workflows;
+  }
+  
+  /**
+   * Get a workflow by name
+   */
+  getWorkflow(name: string): ParsedWorkflow | undefined {
+    return this.getWorkflows().find(w => w.workflow.name === name);
+  }
+  
+  /**
+   * Find workflows that match a trigger context
+   */
+  findMatchingWorkflows(context: TriggerContext): ParsedWorkflow[] {
+    return this.getWorkflows().filter(pw => this.matchesTrigger(pw.workflow, context));
+  }
+  
+  /**
+   * Check if a workflow matches a trigger context
+   */
+  private matchesTrigger(workflow: Workflow, context: TriggerContext): boolean {
+    const trigger = workflow.on;
+    
+    // Handle string/array triggers (already normalized to object in parser)
+    const triggerObj = trigger as Record<string, unknown>;
+    
+    if (!(context.event in triggerObj)) {
+      return false;
+    }
+    
+    const eventConfig = triggerObj[context.event];
+    
+    // Empty config means match all
+    if (!eventConfig || (typeof eventConfig === 'object' && Object.keys(eventConfig).length === 0)) {
+      return true;
+    }
+    
+    // Match based on event type
+    switch (context.event) {
+      case 'push':
+        return this.matchesPush(eventConfig as PushTrigger, context);
+      case 'pull_request':
+      case 'pull_request_target':
+        return this.matchesPullRequest(eventConfig as PullRequestTrigger, context);
+      case 'workflow_dispatch':
+        return true; // Always match if event is in trigger
+      case 'schedule':
+        return true; // Schedule matching is handled by scheduler
+      default:
+        return true;
+    }
+  }
+  
+  /**
+   * Check if push trigger matches
+   */
+  private matchesPush(config: PushTrigger, context: TriggerContext): boolean {
+    // Check branches
+    if (context.branch) {
+      if (config.branches && !this.matchesPattern(context.branch, config.branches)) {
+        return false;
+      }
+      if (config['branches-ignore'] && this.matchesPattern(context.branch, config['branches-ignore'])) {
+        return false;
+      }
+    }
+    
+    // Check tags
+    if (context.tag) {
+      if (config.tags && !this.matchesPattern(context.tag, config.tags)) {
+        return false;
+      }
+      if (config['tags-ignore'] && this.matchesPattern(context.tag, config['tags-ignore'])) {
+        return false;
+      }
+    }
+    
+    // Check paths
+    if (context.paths && context.paths.length > 0) {
+      if (config.paths) {
+        const anyMatch = context.paths.some(p => this.matchesPattern(p, config.paths!));
+        if (!anyMatch) return false;
+      }
+      if (config['paths-ignore']) {
+        const allIgnored = context.paths.every(p => this.matchesPattern(p, config['paths-ignore']!));
+        if (allIgnored) return false;
+      }
+    }
+    
+    return true;
+  }
+  
+  /**
+   * Check if pull request trigger matches
+   */
+  private matchesPullRequest(config: PullRequestTrigger, context: TriggerContext): boolean {
+    // Check branches (target branch for PRs)
+    if (context.branch) {
+      if (config.branches && !this.matchesPattern(context.branch, config.branches)) {
+        return false;
+      }
+      if (config['branches-ignore'] && this.matchesPattern(context.branch, config['branches-ignore'])) {
+        return false;
+      }
+    }
+    
+    // Check paths
+    if (context.paths && context.paths.length > 0) {
+      if (config.paths) {
+        const anyMatch = context.paths.some(p => this.matchesPattern(p, config.paths!));
+        if (!anyMatch) return false;
+      }
+      if (config['paths-ignore']) {
+        const allIgnored = context.paths.every(p => this.matchesPattern(p, config['paths-ignore']!));
+        if (allIgnored) return false;
+      }
+    }
+    
+    // Check PR types
+    if (context.prType && config.types) {
+      const types = config.types as string[];
+      if (!types.includes(context.prType)) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
+  
+  /**
+   * Check if a value matches any of the patterns
+   */
+  private matchesPattern(value: string, patterns: string[]): boolean {
+    return patterns.some(pattern => {
+      // Handle glob patterns
+      if (pattern.includes('*')) {
+        // Convert glob pattern to regex
+        // ** matches any characters including /
+        // * matches any characters except /
+        // ? matches single character
+        let regexStr = '^';
+        let i = 0;
+        while (i < pattern.length) {
+          const char = pattern[i];
+          if (char === '*') {
+            if (pattern[i + 1] === '*') {
+              // ** matches anything including slashes
+              regexStr += '.*';
+              i += 2;
+            } else {
+              // * matches anything except slashes
+              regexStr += '[^/]*';
+              i++;
+            }
+          } else if (char === '?') {
+            regexStr += '.';
+            i++;
+          } else if ('/^$.|+[]{}()\\'.includes(char)) {
+            // Escape regex special characters
+            regexStr += '\\' + char;
+            i++;
+          } else {
+            regexStr += char;
+            i++;
+          }
+        }
+        regexStr += '$';
+        
+        const regex = new RegExp(regexStr);
+        return regex.test(value);
+      }
+      return value === pattern;
+    });
+  }
+  
+  /**
+   * Validate a workflow YAML content
+   */
+  validate(content: string): ValidationResult {
+    return validateWorkflowFile(content);
+  }
+  
+  /**
+   * Initialize the workflows directory
+   */
+  init(): void {
+    const workflowsDir = this.config.workflowsDir!;
+    
+    if (!fs.existsSync(workflowsDir)) {
+      fs.mkdirSync(workflowsDir, { recursive: true });
+    }
+    
+    // Create a sample workflow file
+    const samplePath = path.join(workflowsDir, 'ci.yml.sample');
+    if (!fs.existsSync(samplePath)) {
+      fs.writeFileSync(samplePath, SAMPLE_WORKFLOW);
+    }
+  }
+  
+  /**
+   * Get topologically sorted jobs for a workflow
+   */
+  getJobOrder(workflow: Workflow): string[] {
+    const jobs = workflow.jobs;
+    const jobNames = Object.keys(jobs);
+    const visited = new Set<string>();
+    const result: string[] = [];
+    
+    const visit = (name: string) => {
+      if (visited.has(name)) return;
+      visited.add(name);
+      
+      const job = jobs[name];
+      const needs = job.needs ?? [];
+      
+      for (const dep of needs) {
+        visit(dep);
+      }
+      
+      result.push(name);
+    };
+    
+    for (const name of jobNames) {
+      visit(name);
+    }
+    
+    return result;
+  }
+  
+  /**
+   * Get jobs that can run in parallel (no unmet dependencies)
+   */
+  getParallelJobs(workflow: Workflow, completedJobs: Set<string>): string[] {
+    const jobs = workflow.jobs;
+    const result: string[] = [];
+    
+    for (const [name, job] of Object.entries(jobs)) {
+      if (completedJobs.has(name)) continue;
+      
+      const needs: string[] = Array.isArray(job.needs) ? job.needs : (job.needs ? [job.needs] : []);
+      const allDepsCompleted = needs.every((dep: string) => completedJobs.has(dep));
+      
+      if (allDepsCompleted) {
+        result.push(name);
+      }
+    }
+    
+    return result;
+  }
+}
+
+/**
+ * Sample workflow for new repositories
+ */
+const SAMPLE_WORKFLOW = `# Sample CI workflow
+# Rename this file to ci.yml to enable
+
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: \${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: \${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: \${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+`;
+
+/**
+ * Create a new CI engine for a repository
+ */
+export function createCIEngine(repoPath: string): CIEngine {
+  return new CIEngine({ repoPath });
+}

--- a/src/ci/parser.ts
+++ b/src/ci/parser.ts
@@ -1,0 +1,1087 @@
+/**
+ * CI/CD Workflow Parser
+ * 
+ * Parses and validates workflow YAML files from .wit/workflows/*.yml
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  Workflow,
+  Job,
+  Step,
+  WorkflowTrigger,
+  ParsedWorkflow,
+  ValidationError,
+  ValidationResult,
+  TRIGGER_EVENTS,
+  SHELL_TYPES,
+  EXPRESSION_PATTERN,
+  ACTION_REFERENCE_PATTERN,
+  CRON_PATTERN,
+  TriggerEvent,
+} from './types';
+
+/**
+ * Token types for YAML parsing
+ */
+interface YAMLLine {
+  indent: number;
+  content: string;
+  isArrayItem: boolean;
+  arrayItemContent: string;
+  lineNumber: number;
+}
+
+/**
+ * Simple YAML parser for workflow files
+ * 
+ * This is a lightweight YAML parser that handles the subset of YAML
+ * syntax used in workflow files. For production, consider using
+ * a full YAML library like 'yaml' or 'js-yaml'.
+ */
+export function parseYAML(content: string): unknown {
+  const lines = content.split('\n');
+  const parsedLines: YAMLLine[] = [];
+  
+  // Pre-process lines
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+    
+    const indent = line.search(/\S/);
+    const isArrayItem = trimmed.startsWith('- ');
+    const arrayItemContent = isArrayItem ? trimmed.slice(2) : '';
+    
+    parsedLines.push({
+      indent,
+      content: trimmed,
+      isArrayItem,
+      arrayItemContent,
+      lineNumber: i,
+    });
+  }
+  
+  return parseYAMLLines(parsedLines, 0, parsedLines.length, -1);
+}
+
+/**
+ * Parse a range of YAML lines into an object or array
+ */
+function parseYAMLLines(
+  lines: YAMLLine[],
+  start: number,
+  end: number,
+  parentIndent: number
+): unknown {
+  if (start >= end) return {};
+  
+  const result: Record<string, unknown> = {};
+  let i = start;
+  
+  while (i < end) {
+    const line = lines[i];
+    
+    // Skip lines with less or equal indent than parent (shouldn't happen in normal flow)
+    if (line.indent <= parentIndent && parentIndent >= 0) {
+      break;
+    }
+    
+    if (line.isArrayItem) {
+      // We're at the start of an array - this shouldn't happen at top level
+      // but handle it gracefully
+      i++;
+      continue;
+    }
+    
+    // Parse key-value pair
+    const colonIndex = line.content.indexOf(':');
+    if (colonIndex === -1) {
+      i++;
+      continue;
+    }
+    
+    const key = line.content.slice(0, colonIndex).trim();
+    const valueStr = line.content.slice(colonIndex + 1).trim();
+    const currentIndent = line.indent;
+    
+    // Find the extent of this key's value
+    let valueEnd = i + 1;
+    while (valueEnd < end && lines[valueEnd].indent > currentIndent) {
+      valueEnd++;
+    }
+    
+    if (valueStr === '' || valueStr === '|' || valueStr === '>') {
+      // Check if next line is an array or nested object
+      if (i + 1 < end && lines[i + 1].indent > currentIndent) {
+        if (lines[i + 1].isArrayItem) {
+          // Parse array
+          result[key] = parseYAMLArray(lines, i + 1, valueEnd, currentIndent);
+        } else if (valueStr === '|' || valueStr === '>') {
+          // Multiline string
+          result[key] = parseMultilineString(lines, i + 1, valueEnd, currentIndent);
+        } else {
+          // Nested object
+          result[key] = parseYAMLLines(lines, i + 1, valueEnd, currentIndent);
+        }
+      } else {
+        // Empty value
+        result[key] = valueStr === '' ? {} : '';
+      }
+    } else {
+      // Simple value on same line
+      result[key] = parseValue(valueStr);
+    }
+    
+    i = valueEnd;
+  }
+  
+  return result;
+}
+
+/**
+ * Parse an array from YAML lines
+ */
+function parseYAMLArray(
+  lines: YAMLLine[],
+  start: number,
+  end: number,
+  parentIndent: number
+): unknown[] {
+  const result: unknown[] = [];
+  let i = start;
+  
+  while (i < end) {
+    const line = lines[i];
+    
+    if (line.indent <= parentIndent) {
+      break;
+    }
+    
+    if (!line.isArrayItem) {
+      i++;
+      continue;
+    }
+    
+    const arrayItemIndent = line.indent;
+    const content = line.arrayItemContent;
+    
+    // Find the extent of this array item
+    let itemEnd = i + 1;
+    while (itemEnd < end && 
+           (lines[itemEnd].indent > arrayItemIndent || 
+            (lines[itemEnd].indent === arrayItemIndent && !lines[itemEnd].isArrayItem))) {
+      itemEnd++;
+    }
+    
+    if (content === '') {
+      // Empty array item - check if it's a nested structure
+      if (i + 1 < end && lines[i + 1].indent > arrayItemIndent) {
+        result.push(parseYAMLLines(lines, i + 1, itemEnd, arrayItemIndent));
+      } else {
+        result.push(null);
+      }
+    } else if (content.includes(':')) {
+      // Object in array item
+      const colonIndex = content.indexOf(':');
+      const key = content.slice(0, colonIndex).trim();
+      const valueStr = content.slice(colonIndex + 1).trim();
+      
+      const obj: Record<string, unknown> = {};
+      
+      if (valueStr === '') {
+        // Nested value for this key
+        if (i + 1 < end && lines[i + 1].indent > arrayItemIndent) {
+          // Check if next indented content is for this key or sibling keys
+          const nextLine = lines[i + 1];
+          if (nextLine.isArrayItem) {
+            obj[key] = parseYAMLArray(lines, i + 1, itemEnd, arrayItemIndent);
+          } else {
+            // Could be nested object for this key or sibling keys
+            // Parse all as siblings of the first key
+            const nested = parseYAMLLines(lines, i + 1, itemEnd, arrayItemIndent);
+            if (typeof nested === 'object' && nested !== null) {
+              Object.assign(obj, { [key]: {} }, nested);
+            } else {
+              obj[key] = nested;
+            }
+          }
+        } else {
+          obj[key] = {};
+        }
+      } else {
+        obj[key] = parseValue(valueStr);
+        
+        // Check for additional properties in the array item
+        if (i + 1 < end && lines[i + 1].indent > arrayItemIndent && !lines[i + 1].isArrayItem) {
+          const additional = parseYAMLLines(lines, i + 1, itemEnd, arrayItemIndent);
+          if (typeof additional === 'object' && additional !== null) {
+            Object.assign(obj, additional);
+          }
+        }
+      }
+      
+      result.push(obj);
+    } else {
+      // Simple value in array
+      result.push(parseValue(content));
+    }
+    
+    i = itemEnd;
+  }
+  
+  return result;
+}
+
+/**
+ * Parse a multiline string from YAML lines
+ */
+function parseMultilineString(
+  lines: YAMLLine[],
+  start: number,
+  end: number,
+  parentIndent: number
+): string {
+  const parts: string[] = [];
+  
+  for (let i = start; i < end; i++) {
+    const line = lines[i];
+    if (line.indent <= parentIndent) {
+      break;
+    }
+    parts.push(line.content);
+  }
+  
+  return parts.join('\n');
+}
+
+/**
+ * Parse a YAML value string
+ */
+function parseValue(value: string): unknown {
+  // Handle quoted strings
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  
+  // Handle booleans
+  if (value === 'true' || value === 'True' || value === 'TRUE') {
+    return true;
+  }
+  if (value === 'false' || value === 'False' || value === 'FALSE') {
+    return false;
+  }
+  
+  // Handle null
+  if (value === 'null' || value === 'Null' || value === 'NULL' || value === '~') {
+    return null;
+  }
+  
+  // Handle numbers
+  if (/^-?\d+$/.test(value)) {
+    return parseInt(value, 10);
+  }
+  if (/^-?\d+\.\d+$/.test(value)) {
+    return parseFloat(value);
+  }
+  
+  // Handle inline arrays
+  if (value.startsWith('[') && value.endsWith(']')) {
+    const inner = value.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(',').map(v => parseValue(v.trim()));
+  }
+  
+  // Handle inline objects
+  if (value.startsWith('{') && value.endsWith('}')) {
+    const inner = value.slice(1, -1).trim();
+    if (!inner) return {};
+    const obj: Record<string, unknown> = {};
+    const pairs = inner.split(',');
+    for (const pair of pairs) {
+      const [k, v] = pair.split(':').map(s => s.trim());
+      if (k && v !== undefined) {
+        obj[k] = parseValue(v);
+      }
+    }
+    return obj;
+  }
+  
+  // Default to string
+  return value;
+}
+
+/**
+ * Parse workflow YAML content into a Workflow object
+ */
+export function parseWorkflow(content: string): Workflow {
+  const raw = parseYAML(content);
+  return validateWorkflow(raw);
+}
+
+/**
+ * Validate and type-check a raw parsed workflow
+ */
+export function validateWorkflow(raw: unknown): Workflow {
+  const errors: ValidationError[] = [];
+  
+  if (!raw || typeof raw !== 'object') {
+    throw new WorkflowValidationError('Workflow must be an object', [
+      { message: 'Workflow must be an object', path: '', severity: 'error' },
+    ]);
+  }
+  
+  const obj = raw as Record<string, unknown>;
+  
+  // Validate name (required)
+  if (!obj.name || typeof obj.name !== 'string') {
+    errors.push({
+      message: 'Workflow must have a "name" field',
+      path: 'name',
+      severity: 'error',
+    });
+  }
+  
+  // Validate 'on' trigger (required)
+  if (!obj.on) {
+    errors.push({
+      message: 'Workflow must have an "on" trigger field',
+      path: 'on',
+      severity: 'error',
+    });
+  } else {
+    const triggerErrors = validateTrigger(obj.on);
+    errors.push(...triggerErrors);
+  }
+  
+  // Validate jobs (required)
+  if (!obj.jobs || typeof obj.jobs !== 'object') {
+    errors.push({
+      message: 'Workflow must have a "jobs" field',
+      path: 'jobs',
+      severity: 'error',
+    });
+  } else {
+    const jobsObj = obj.jobs as Record<string, unknown>;
+    const jobNames = Object.keys(jobsObj);
+    
+    if (jobNames.length === 0) {
+      errors.push({
+        message: 'Workflow must have at least one job',
+        path: 'jobs',
+        severity: 'error',
+      });
+    }
+    
+    // Validate each job
+    for (const jobName of jobNames) {
+      const jobErrors = validateJob(jobsObj[jobName], jobName, jobNames);
+      errors.push(...jobErrors);
+    }
+    
+    // Check for circular dependencies
+    const cycleErrors = detectJobCycles(jobsObj);
+    errors.push(...cycleErrors);
+  }
+  
+  // Validate env if present
+  if (obj.env !== undefined && typeof obj.env !== 'object') {
+    errors.push({
+      message: 'env must be an object',
+      path: 'env',
+      severity: 'error',
+    });
+  }
+  
+  if (errors.filter(e => e.severity === 'error').length > 0) {
+    throw new WorkflowValidationError(
+      'Workflow validation failed',
+      errors
+    );
+  }
+  
+  // Normalize the trigger
+  const normalizedTrigger = normalizeTrigger(obj.on);
+  
+  return {
+    name: obj.name as string,
+    on: normalizedTrigger,
+    env: obj.env as Record<string, string> | undefined,
+    jobs: normalizeJobs(obj.jobs as Record<string, unknown>),
+    defaults: obj.defaults as Workflow['defaults'],
+    concurrency: obj.concurrency as Workflow['concurrency'],
+    permissions: obj.permissions as Workflow['permissions'],
+  };
+}
+
+/**
+ * Validate trigger configuration
+ */
+function validateTrigger(trigger: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+  
+  // Handle string trigger (e.g., "push")
+  if (typeof trigger === 'string') {
+    if (!TRIGGER_EVENTS.includes(trigger as TriggerEvent)) {
+      errors.push({
+        message: `Invalid trigger event: "${trigger}"`,
+        path: 'on',
+        severity: 'error',
+      });
+    }
+    return errors;
+  }
+  
+  // Handle array trigger (e.g., ["push", "pull_request"])
+  if (Array.isArray(trigger)) {
+    for (let i = 0; i < trigger.length; i++) {
+      if (typeof trigger[i] !== 'string') {
+        errors.push({
+          message: `Trigger event at index ${i} must be a string`,
+          path: `on[${i}]`,
+          severity: 'error',
+        });
+      } else if (!TRIGGER_EVENTS.includes(trigger[i] as TriggerEvent)) {
+        errors.push({
+          message: `Invalid trigger event: "${trigger[i]}"`,
+          path: `on[${i}]`,
+          severity: 'error',
+        });
+      }
+    }
+    return errors;
+  }
+  
+  // Handle object trigger
+  if (typeof trigger === 'object' && trigger !== null) {
+    const triggerObj = trigger as Record<string, unknown>;
+    
+    for (const eventName of Object.keys(triggerObj)) {
+      if (!TRIGGER_EVENTS.includes(eventName as TriggerEvent)) {
+        errors.push({
+          message: `Invalid trigger event: "${eventName}"`,
+          path: `on.${eventName}`,
+          severity: 'error',
+        });
+      }
+      
+      // Validate schedule cron expressions
+      if (eventName === 'schedule') {
+        const schedules = triggerObj.schedule;
+        if (Array.isArray(schedules)) {
+          for (let i = 0; i < schedules.length; i++) {
+            const schedule = schedules[i] as Record<string, unknown>;
+            if (!schedule.cron || typeof schedule.cron !== 'string') {
+              errors.push({
+                message: 'Schedule entry must have a "cron" field',
+                path: `on.schedule[${i}]`,
+                severity: 'error',
+              });
+            } else if (!CRON_PATTERN.test(schedule.cron)) {
+              errors.push({
+                message: `Invalid cron expression: "${schedule.cron}"`,
+                path: `on.schedule[${i}].cron`,
+                severity: 'warning',
+              });
+            }
+          }
+        }
+      }
+    }
+    
+    return errors;
+  }
+  
+  errors.push({
+    message: 'Invalid trigger format',
+    path: 'on',
+    severity: 'error',
+  });
+  
+  return errors;
+}
+
+/**
+ * Validate a job definition
+ */
+function validateJob(job: unknown, jobName: string, allJobNames: string[]): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const basePath = `jobs.${jobName}`;
+  
+  if (!job || typeof job !== 'object') {
+    errors.push({
+      message: 'Job must be an object',
+      path: basePath,
+      severity: 'error',
+    });
+    return errors;
+  }
+  
+  const jobObj = job as Record<string, unknown>;
+  
+  // Validate runs-on (required)
+  if (!jobObj['runs-on']) {
+    errors.push({
+      message: 'Job must have a "runs-on" field',
+      path: `${basePath}.runs-on`,
+      severity: 'error',
+    });
+  }
+  
+  // Validate steps (required)
+  if (!jobObj.steps) {
+    errors.push({
+      message: 'Job must have a "steps" field',
+      path: `${basePath}.steps`,
+      severity: 'error',
+    });
+  } else if (!Array.isArray(jobObj.steps)) {
+    errors.push({
+      message: 'steps must be an array',
+      path: `${basePath}.steps`,
+      severity: 'error',
+    });
+  } else if (jobObj.steps.length === 0) {
+    errors.push({
+      message: 'Job must have at least one step',
+      path: `${basePath}.steps`,
+      severity: 'error',
+    });
+  } else {
+    // Validate each step
+    const stepIds = new Set<string>();
+    for (let i = 0; i < jobObj.steps.length; i++) {
+      const stepErrors = validateStep(jobObj.steps[i], i, basePath, stepIds);
+      errors.push(...stepErrors);
+    }
+  }
+  
+  // Validate needs (job dependencies)
+  if (jobObj.needs !== undefined) {
+    const needs = Array.isArray(jobObj.needs) ? jobObj.needs : [jobObj.needs];
+    for (const need of needs) {
+      if (typeof need !== 'string') {
+        errors.push({
+          message: 'Job dependency must be a string',
+          path: `${basePath}.needs`,
+          severity: 'error',
+        });
+      } else if (!allJobNames.includes(need)) {
+        errors.push({
+          message: `Job dependency "${need}" does not exist`,
+          path: `${basePath}.needs`,
+          severity: 'error',
+        });
+      } else if (need === jobName) {
+        errors.push({
+          message: 'Job cannot depend on itself',
+          path: `${basePath}.needs`,
+          severity: 'error',
+        });
+      }
+    }
+  }
+  
+  // Validate if condition expression
+  if (jobObj.if !== undefined && typeof jobObj.if !== 'string') {
+    errors.push({
+      message: 'if condition must be a string',
+      path: `${basePath}.if`,
+      severity: 'error',
+    });
+  }
+  
+  // Validate env
+  if (jobObj.env !== undefined && typeof jobObj.env !== 'object') {
+    errors.push({
+      message: 'env must be an object',
+      path: `${basePath}.env`,
+      severity: 'error',
+    });
+  }
+  
+  // Validate timeout-minutes
+  if (jobObj['timeout-minutes'] !== undefined) {
+    if (typeof jobObj['timeout-minutes'] !== 'number' || jobObj['timeout-minutes'] <= 0) {
+      errors.push({
+        message: 'timeout-minutes must be a positive number',
+        path: `${basePath}.timeout-minutes`,
+        severity: 'error',
+      });
+    }
+  }
+  
+  return errors;
+}
+
+/**
+ * Validate a step definition
+ */
+function validateStep(
+  step: unknown,
+  index: number,
+  jobPath: string,
+  stepIds: Set<string>
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const basePath = `${jobPath}.steps[${index}]`;
+  
+  if (!step || typeof step !== 'object') {
+    errors.push({
+      message: 'Step must be an object',
+      path: basePath,
+      severity: 'error',
+    });
+    return errors;
+  }
+  
+  const stepObj = step as Record<string, unknown>;
+  
+  // Step must have either 'uses' or 'run'
+  if (!stepObj.uses && !stepObj.run) {
+    errors.push({
+      message: 'Step must have either "uses" or "run"',
+      path: basePath,
+      severity: 'error',
+    });
+  }
+  
+  // Cannot have both 'uses' and 'run'
+  if (stepObj.uses && stepObj.run) {
+    errors.push({
+      message: 'Step cannot have both "uses" and "run"',
+      path: basePath,
+      severity: 'error',
+    });
+  }
+  
+  // Validate id uniqueness
+  if (stepObj.id !== undefined) {
+    if (typeof stepObj.id !== 'string') {
+      errors.push({
+        message: 'Step id must be a string',
+        path: `${basePath}.id`,
+        severity: 'error',
+      });
+    } else if (stepIds.has(stepObj.id)) {
+      errors.push({
+        message: `Duplicate step id: "${stepObj.id}"`,
+        path: `${basePath}.id`,
+        severity: 'error',
+      });
+    } else {
+      stepIds.add(stepObj.id);
+    }
+  }
+  
+  // Validate uses (action reference)
+  if (stepObj.uses !== undefined) {
+    if (typeof stepObj.uses !== 'string') {
+      errors.push({
+        message: 'uses must be a string',
+        path: `${basePath}.uses`,
+        severity: 'error',
+      });
+    } else if (!ACTION_REFERENCE_PATTERN.test(stepObj.uses)) {
+      // Allow docker:// references as well
+      if (!stepObj.uses.startsWith('docker://')) {
+        errors.push({
+          message: `Invalid action reference: "${stepObj.uses}"`,
+          path: `${basePath}.uses`,
+          severity: 'warning',
+        });
+      }
+    }
+  }
+  
+  // Validate run
+  if (stepObj.run !== undefined && typeof stepObj.run !== 'string') {
+    errors.push({
+      message: 'run must be a string',
+      path: `${basePath}.run`,
+      severity: 'error',
+    });
+  }
+  
+  // Validate shell
+  if (stepObj.shell !== undefined) {
+    if (typeof stepObj.shell !== 'string') {
+      errors.push({
+        message: 'shell must be a string',
+        path: `${basePath}.shell`,
+        severity: 'error',
+      });
+    } else if (!SHELL_TYPES.includes(stepObj.shell as typeof SHELL_TYPES[number])) {
+      errors.push({
+        message: `Invalid shell type: "${stepObj.shell}"`,
+        path: `${basePath}.shell`,
+        severity: 'warning',
+      });
+    }
+  }
+  
+  // Validate if condition
+  if (stepObj.if !== undefined && typeof stepObj.if !== 'string') {
+    errors.push({
+      message: 'if condition must be a string',
+      path: `${basePath}.if`,
+      severity: 'error',
+    });
+  }
+  
+  // Validate timeout-minutes
+  if (stepObj['timeout-minutes'] !== undefined) {
+    if (typeof stepObj['timeout-minutes'] !== 'number' || stepObj['timeout-minutes'] <= 0) {
+      errors.push({
+        message: 'timeout-minutes must be a positive number',
+        path: `${basePath}.timeout-minutes`,
+        severity: 'error',
+      });
+    }
+  }
+  
+  // Validate continue-on-error
+  if (stepObj['continue-on-error'] !== undefined && typeof stepObj['continue-on-error'] !== 'boolean') {
+    errors.push({
+      message: 'continue-on-error must be a boolean',
+      path: `${basePath}.continue-on-error`,
+      severity: 'error',
+    });
+  }
+  
+  return errors;
+}
+
+/**
+ * Detect circular dependencies in job definitions
+ */
+function detectJobCycles(jobs: Record<string, unknown>): ValidationError[] {
+  const errors: ValidationError[] = [];
+  const visited = new Set<string>();
+  const recursionStack = new Set<string>();
+  
+  function hasCycle(jobName: string, path: string[]): string[] | null {
+    if (recursionStack.has(jobName)) {
+      return [...path, jobName];
+    }
+    
+    if (visited.has(jobName)) {
+      return null;
+    }
+    
+    visited.add(jobName);
+    recursionStack.add(jobName);
+    
+    const job = jobs[jobName] as Record<string, unknown> | undefined;
+    if (job && job.needs) {
+      const needs = Array.isArray(job.needs) ? job.needs : [job.needs];
+      for (const dep of needs) {
+        if (typeof dep === 'string') {
+          const cycle = hasCycle(dep, [...path, jobName]);
+          if (cycle) {
+            return cycle;
+          }
+        }
+      }
+    }
+    
+    recursionStack.delete(jobName);
+    return null;
+  }
+  
+  for (const jobName of Object.keys(jobs)) {
+    visited.clear();
+    recursionStack.clear();
+    const cycle = hasCycle(jobName, []);
+    if (cycle) {
+      errors.push({
+        message: `Circular dependency detected: ${cycle.join(' -> ')}`,
+        path: 'jobs',
+        severity: 'error',
+      });
+      break; // Only report one cycle
+    }
+  }
+  
+  return errors;
+}
+
+/**
+ * Normalize trigger to WorkflowTrigger object
+ */
+function normalizeTrigger(trigger: unknown): WorkflowTrigger {
+  if (typeof trigger === 'string') {
+    return { [trigger]: {} } as WorkflowTrigger;
+  }
+  
+  if (Array.isArray(trigger)) {
+    const result: WorkflowTrigger = {};
+    for (const event of trigger) {
+      if (typeof event === 'string') {
+        (result as Record<string, unknown>)[event] = {};
+      }
+    }
+    return result;
+  }
+  
+  return trigger as WorkflowTrigger;
+}
+
+/**
+ * Normalize jobs to proper Job objects
+ */
+function normalizeJobs(jobs: Record<string, unknown>): Record<string, Job> {
+  const result: Record<string, Job> = {};
+  
+  for (const [name, job] of Object.entries(jobs)) {
+    const jobObj = job as Record<string, unknown>;
+    
+    result[name] = {
+      name: jobObj.name as string | undefined,
+      'runs-on': jobObj['runs-on'] as string | string[],
+      needs: normalizeNeeds(jobObj.needs),
+      if: jobObj.if as string | undefined,
+      env: jobObj.env as Record<string, string> | undefined,
+      steps: normalizeSteps(jobObj.steps as unknown[]),
+      services: jobObj.services as Record<string, Job['services']>[string] | undefined,
+      container: jobObj.container as Job['container'],
+      outputs: jobObj.outputs as Record<string, string> | undefined,
+      strategy: jobObj.strategy as Job['strategy'],
+      'continue-on-error': jobObj['continue-on-error'] as boolean | undefined,
+      'timeout-minutes': jobObj['timeout-minutes'] as number | undefined,
+      concurrency: jobObj.concurrency as Job['concurrency'],
+      permissions: jobObj.permissions as Job['permissions'],
+      environment: jobObj.environment as Job['environment'],
+      defaults: jobObj.defaults as Job['defaults'],
+    };
+  }
+  
+  return result;
+}
+
+/**
+ * Normalize needs to string array or undefined
+ */
+function normalizeNeeds(needs: unknown): string[] | undefined {
+  if (needs === undefined) {
+    return undefined;
+  }
+  if (typeof needs === 'string') {
+    return [needs];
+  }
+  if (Array.isArray(needs)) {
+    return needs.filter(n => typeof n === 'string');
+  }
+  return undefined;
+}
+
+/**
+ * Normalize steps to proper Step objects
+ */
+function normalizeSteps(steps: unknown[]): Step[] {
+  return steps.map(step => {
+    const stepObj = step as Record<string, unknown>;
+    return {
+      name: stepObj.name as string | undefined,
+      id: stepObj.id as string | undefined,
+      uses: stepObj.uses as string | undefined,
+      run: stepObj.run as string | undefined,
+      with: stepObj.with as Record<string, string | number | boolean> | undefined,
+      env: stepObj.env as Record<string, string> | undefined,
+      if: stepObj.if as string | undefined,
+      'working-directory': stepObj['working-directory'] as string | undefined,
+      shell: stepObj.shell as string | undefined,
+      'continue-on-error': stepObj['continue-on-error'] as boolean | undefined,
+      'timeout-minutes': stepObj['timeout-minutes'] as number | undefined,
+    };
+  });
+}
+
+/**
+ * Load all workflow files from a repository
+ */
+export function loadWorkflows(repoPath: string): ParsedWorkflow[] {
+  const workflowDir = path.join(repoPath, '.wit', 'workflows');
+  const workflows: ParsedWorkflow[] = [];
+  
+  if (!fs.existsSync(workflowDir)) {
+    return workflows;
+  }
+  
+  const files = fs.readdirSync(workflowDir);
+  
+  for (const file of files) {
+    if (!file.endsWith('.yml') && !file.endsWith('.yaml')) {
+      continue;
+    }
+    
+    const filePath = path.join(workflowDir, file);
+    const content = fs.readFileSync(filePath, 'utf8');
+    
+    try {
+      const workflow = parseWorkflow(content);
+      workflows.push({
+        workflow,
+        filePath,
+        rawContent: content,
+      });
+    } catch (error) {
+      if (error instanceof WorkflowValidationError) {
+        throw new WorkflowLoadError(
+          `Failed to load workflow "${file}": ${error.message}`,
+          filePath,
+          error.errors
+        );
+      }
+      throw error;
+    }
+  }
+  
+  return workflows;
+}
+
+/**
+ * Load a single workflow file
+ */
+export function loadWorkflowFile(filePath: string): ParsedWorkflow {
+  if (!fs.existsSync(filePath)) {
+    throw new WorkflowLoadError(`Workflow file not found: ${filePath}`, filePath, []);
+  }
+  
+  const content = fs.readFileSync(filePath, 'utf8');
+  
+  try {
+    const workflow = parseWorkflow(content);
+    return {
+      workflow,
+      filePath,
+      rawContent: content,
+    };
+  } catch (error) {
+    if (error instanceof WorkflowValidationError) {
+      throw new WorkflowLoadError(
+        `Failed to load workflow "${path.basename(filePath)}": ${error.message}`,
+        filePath,
+        error.errors
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Validate a workflow and return validation result
+ */
+export function validateWorkflowFile(content: string): ValidationResult {
+  const errors: ValidationError[] = [];
+  const warnings: ValidationError[] = [];
+  
+  try {
+    parseWorkflow(content);
+    return { valid: true, errors: [], warnings: [] };
+  } catch (error) {
+    if (error instanceof WorkflowValidationError) {
+      for (const err of error.errors) {
+        if (err.severity === 'error') {
+          errors.push(err);
+        } else {
+          warnings.push(err);
+        }
+      }
+      return { valid: false, errors, warnings };
+    }
+    
+    errors.push({
+      message: error instanceof Error ? error.message : 'Unknown error',
+      path: '',
+      severity: 'error',
+    });
+    return { valid: false, errors, warnings };
+  }
+}
+
+/**
+ * Check if an expression contains valid syntax
+ */
+export function validateExpression(expression: string): ValidationError[] {
+  const errors: ValidationError[] = [];
+  
+  // Check for balanced braces
+  const matches = expression.match(EXPRESSION_PATTERN);
+  if (!matches) {
+    return errors;
+  }
+  
+  for (const match of matches) {
+    const inner = match.slice(3, -2).trim();
+    
+    // Check for empty expression
+    if (!inner) {
+      errors.push({
+        message: 'Empty expression',
+        path: '',
+        severity: 'warning',
+      });
+      continue;
+    }
+    
+    // Basic syntax checks (more could be added)
+    // Check for unbalanced parentheses
+    let parenCount = 0;
+    for (const char of inner) {
+      if (char === '(') parenCount++;
+      if (char === ')') parenCount--;
+      if (parenCount < 0) {
+        errors.push({
+          message: 'Unbalanced parentheses in expression',
+          path: '',
+          severity: 'error',
+        });
+        break;
+      }
+    }
+    
+    if (parenCount > 0) {
+      errors.push({
+        message: 'Unclosed parentheses in expression',
+        path: '',
+        severity: 'error',
+      });
+    }
+  }
+  
+  return errors;
+}
+
+/**
+ * Custom error for workflow validation failures
+ */
+export class WorkflowValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly errors: ValidationError[]
+  ) {
+    super(message);
+    this.name = 'WorkflowValidationError';
+  }
+}
+
+/**
+ * Custom error for workflow loading failures
+ */
+export class WorkflowLoadError extends Error {
+  constructor(
+    message: string,
+    public readonly filePath: string,
+    public readonly errors: ValidationError[]
+  ) {
+    super(message);
+    this.name = 'WorkflowLoadError';
+  }
+}

--- a/src/ci/types.ts
+++ b/src/ci/types.ts
@@ -1,0 +1,356 @@
+/**
+ * CI/CD Workflow Types
+ * 
+ * Type definitions for workflow YAML files in .wit/workflows/*.yml
+ * Compatible with GitHub Actions syntax.
+ */
+
+/**
+ * Input definition for workflow_dispatch trigger
+ */
+export interface InputDef {
+  description?: string;
+  required?: boolean;
+  default?: string;
+  type?: 'string' | 'boolean' | 'choice' | 'environment';
+  options?: string[];
+}
+
+/**
+ * Push trigger configuration
+ */
+export interface PushTrigger {
+  branches?: string[];
+  'branches-ignore'?: string[];
+  tags?: string[];
+  'tags-ignore'?: string[];
+  paths?: string[];
+  'paths-ignore'?: string[];
+}
+
+/**
+ * Pull request trigger configuration
+ */
+export interface PullRequestTrigger {
+  branches?: string[];
+  'branches-ignore'?: string[];
+  paths?: string[];
+  'paths-ignore'?: string[];
+  types?: (
+    | 'opened'
+    | 'closed'
+    | 'reopened'
+    | 'synchronize'
+    | 'edited'
+    | 'ready_for_review'
+    | 'labeled'
+    | 'unlabeled'
+    | 'assigned'
+    | 'unassigned'
+    | 'review_requested'
+    | 'review_request_removed'
+  )[];
+}
+
+/**
+ * Schedule trigger configuration
+ */
+export interface ScheduleTrigger {
+  cron: string;
+}
+
+/**
+ * Workflow dispatch trigger configuration
+ */
+export interface WorkflowDispatchTrigger {
+  inputs?: Record<string, InputDef>;
+}
+
+/**
+ * Workflow call trigger for reusable workflows
+ */
+export interface WorkflowCallTrigger {
+  inputs?: Record<string, InputDef>;
+  outputs?: Record<string, { description?: string; value: string }>;
+  secrets?: Record<string, { description?: string; required?: boolean }>;
+}
+
+/**
+ * Workflow trigger configuration
+ */
+export interface WorkflowTrigger {
+  push?: PushTrigger;
+  pull_request?: PullRequestTrigger;
+  pull_request_target?: PullRequestTrigger;
+  workflow_dispatch?: WorkflowDispatchTrigger;
+  workflow_call?: WorkflowCallTrigger;
+  schedule?: ScheduleTrigger[];
+  repository_dispatch?: {
+    types?: string[];
+  };
+  release?: {
+    types?: ('published' | 'unpublished' | 'created' | 'edited' | 'deleted' | 'prereleased' | 'released')[];
+  };
+  issues?: {
+    types?: ('opened' | 'edited' | 'deleted' | 'transferred' | 'pinned' | 'unpinned' | 'closed' | 'reopened' | 'assigned' | 'unassigned' | 'labeled' | 'unlabeled' | 'milestoned' | 'demilestoned')[];
+  };
+  workflow_run?: {
+    workflows: string[];
+    types?: ('completed' | 'requested' | 'in_progress')[];
+    branches?: string[];
+    'branches-ignore'?: string[];
+  };
+}
+
+/**
+ * Service container configuration
+ */
+export interface Service {
+  image: string;
+  credentials?: {
+    username: string;
+    password: string;
+  };
+  env?: Record<string, string>;
+  ports?: (string | number)[];
+  volumes?: string[];
+  options?: string;
+}
+
+/**
+ * Container configuration for job
+ */
+export interface Container {
+  image: string;
+  credentials?: {
+    username: string;
+    password: string;
+  };
+  env?: Record<string, string>;
+  ports?: (string | number)[];
+  volumes?: string[];
+  options?: string;
+}
+
+/**
+ * Matrix configuration
+ */
+export interface MatrixConfig {
+  [key: string]: unknown[] | Record<string, unknown>[] | undefined;
+}
+
+/**
+ * Strategy configuration for matrix builds
+ */
+export interface Strategy {
+  matrix?: MatrixConfig;
+  'fail-fast'?: boolean;
+  'max-parallel'?: number;
+}
+
+/**
+ * Concurrency configuration
+ */
+export interface Concurrency {
+  group: string;
+  'cancel-in-progress'?: boolean;
+}
+
+/**
+ * Defaults configuration
+ */
+export interface Defaults {
+  run?: {
+    shell?: string;
+    'working-directory'?: string;
+  };
+}
+
+/**
+ * Permissions configuration
+ */
+export type PermissionLevel = 'read' | 'write' | 'none';
+export type Permissions =
+  | 'read-all'
+  | 'write-all'
+  | {
+      actions?: PermissionLevel;
+      checks?: PermissionLevel;
+      contents?: PermissionLevel;
+      deployments?: PermissionLevel;
+      discussions?: PermissionLevel;
+      'id-token'?: PermissionLevel;
+      issues?: PermissionLevel;
+      packages?: PermissionLevel;
+      pages?: PermissionLevel;
+      'pull-requests'?: PermissionLevel;
+      'repository-projects'?: PermissionLevel;
+      'security-events'?: PermissionLevel;
+      statuses?: PermissionLevel;
+    };
+
+/**
+ * Step definition in a job
+ */
+export interface Step {
+  /** Display name for the step */
+  name?: string;
+  /** Unique identifier for referencing step outputs */
+  id?: string;
+  /** Action reference (e.g., actions/checkout@v4) */
+  uses?: string;
+  /** Shell command to run */
+  run?: string;
+  /** Inputs passed to the action */
+  with?: Record<string, string | number | boolean>;
+  /** Environment variables for this step */
+  env?: Record<string, string>;
+  /** Conditional expression */
+  if?: string;
+  /** Working directory for run commands */
+  'working-directory'?: string;
+  /** Shell to use (bash, pwsh, python, sh, cmd, powershell) */
+  shell?: string;
+  /** Continue workflow if step fails */
+  'continue-on-error'?: boolean;
+  /** Maximum minutes to run before killing */
+  'timeout-minutes'?: number;
+}
+
+/**
+ * Job definition in a workflow
+ */
+export interface Job {
+  /** Display name for the job */
+  name?: string;
+  /** Runner label (e.g., ubuntu-latest, self-hosted) */
+  'runs-on': string | string[];
+  /** Jobs that must complete before this job runs */
+  needs?: string | string[];
+  /** Conditional expression */
+  if?: string;
+  /** Environment variables for all steps */
+  env?: Record<string, string>;
+  /** Steps to execute */
+  steps: Step[];
+  /** Service containers */
+  services?: Record<string, Service>;
+  /** Container to run job in */
+  container?: string | Container;
+  /** Outputs from this job */
+  outputs?: Record<string, string>;
+  /** Matrix strategy */
+  strategy?: Strategy;
+  /** Continue workflow if job fails */
+  'continue-on-error'?: boolean;
+  /** Maximum minutes to run before killing */
+  'timeout-minutes'?: number;
+  /** Concurrency settings */
+  concurrency?: string | Concurrency;
+  /** Permissions for this job */
+  permissions?: Permissions;
+  /** Environment to deploy to */
+  environment?: string | {
+    name: string;
+    url?: string;
+  };
+  /** Default settings for run steps */
+  defaults?: Defaults;
+}
+
+/**
+ * Complete workflow definition
+ */
+export interface Workflow {
+  /** Workflow name */
+  name: string;
+  /** Trigger events */
+  on: WorkflowTrigger | string | string[];
+  /** Global environment variables */
+  env?: Record<string, string>;
+  /** Jobs to run */
+  jobs: Record<string, Job>;
+  /** Default settings */
+  defaults?: Defaults;
+  /** Concurrency settings */
+  concurrency?: string | Concurrency;
+  /** Permissions for the workflow */
+  permissions?: Permissions;
+}
+
+/**
+ * Parsed workflow with metadata
+ */
+export interface ParsedWorkflow {
+  /** The parsed workflow */
+  workflow: Workflow;
+  /** Source file path */
+  filePath: string;
+  /** Raw YAML content */
+  rawContent: string;
+}
+
+/**
+ * Validation error for workflow parsing
+ */
+export interface ValidationError {
+  /** Error message */
+  message: string;
+  /** Path to the error in the workflow (e.g., 'jobs.build.steps[0]') */
+  path: string;
+  /** Line number in source file (if available) */
+  line?: number;
+  /** Severity level */
+  severity: 'error' | 'warning';
+}
+
+/**
+ * Validation result for a workflow
+ */
+export interface ValidationResult {
+  /** Whether the workflow is valid */
+  valid: boolean;
+  /** List of validation errors */
+  errors: ValidationError[];
+  /** List of validation warnings */
+  warnings: ValidationError[];
+}
+
+/**
+ * Trigger event types
+ */
+export const TRIGGER_EVENTS = [
+  'push',
+  'pull_request',
+  'pull_request_target',
+  'workflow_dispatch',
+  'workflow_call',
+  'schedule',
+  'repository_dispatch',
+  'release',
+  'issues',
+  'workflow_run',
+] as const;
+
+export type TriggerEvent = typeof TRIGGER_EVENTS[number];
+
+/**
+ * Valid shell types
+ */
+export const SHELL_TYPES = ['bash', 'pwsh', 'python', 'sh', 'cmd', 'powershell'] as const;
+export type ShellType = typeof SHELL_TYPES[number];
+
+/**
+ * Expression pattern for ${{ ... }} syntax
+ */
+export const EXPRESSION_PATTERN = /\$\{\{[\s\S]*?\}\}/g;
+
+/**
+ * Action reference pattern (owner/repo@ref or ./local/path)
+ */
+export const ACTION_REFERENCE_PATTERN = /^(?:\.\/[\w\-./]+|[\w\-]+\/[\w\-]+(?:\/[\w\-./]+)?@[\w\-./]+)$/;
+
+/**
+ * Cron expression pattern (basic validation)
+ */
+export const CRON_PATTERN = /^(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)\s+(\*|[0-9,\-\/]+)$/;


### PR DESCRIPTION
## Summary

Implements a GitHub Actions-compatible CI/CD workflow YAML parser for wit. This is the foundation for wit's built-in CI/CD engine, allowing workflows to be defined in `.wit/workflows/*.yml` files.

## Changes

- **`src/ci/types.ts`** - Complete type definitions for workflows, jobs, steps, triggers, services, containers, and validation
- **`src/ci/parser.ts`** - YAML parser and workflow validation with circular dependency detection
- **`src/ci/index.ts`** - CIEngine class for loading, querying, and matching workflows
- **`src/ci/__tests__/parser.test.ts`** - 58 comprehensive tests

## Features

- Parses GitHub Actions-compatible YAML workflow syntax
- Validates required fields, job dependencies, step configurations
- Detects circular dependencies in job `needs` declarations
- Supports all trigger types (push, pull_request, workflow_dispatch, schedule, etc.)
- Glob pattern matching for branches/paths (`*` = single segment, `**` = any depth)
- Expression syntax validation (`${{ ... }}`)
- CIEngine provides job ordering and parallel execution planning

## Testing

All 58 new tests pass, and all 455 existing tests continue to pass.