### PR TITLE
feat: integrate stacks with PRs for first-class stacked diffs support

### DIFF
--- a/apps/web/src/routes/repo/pull-detail.tsx
+++ b/apps/web/src/routes/repo/pull-detail.tsx
@@ -12,6 +12,9 @@ import {
   CheckCircle,
   AlertCircle,
   Loader2,
+  Layers,
+  ArrowRight,
+  Circle,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -271,6 +274,63 @@ export function PullDetailPage() {
             </Badge>
           ))}
         </div>
+
+        {/* Stack context */}
+        {pr.stack && (
+          <Card className="mt-4 bg-muted/30">
+            <CardContent className="p-3">
+              <div className="flex items-center gap-2 mb-2">
+                <Layers className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">Part of stack:</span>
+                <Link 
+                  to={`/${owner}/${repo}/stacks/${pr.stack.name}`}
+                  className="text-sm text-primary hover:underline"
+                >
+                  {pr.stack.name}
+                </Link>
+              </div>
+              <div className="flex items-center gap-1 flex-wrap text-xs">
+                <code className="bg-muted px-1.5 py-0.5 rounded">{pr.stack.baseBranch}</code>
+                {pr.stack.branches.map((branch, idx) => {
+                  const isCurrentPR = branch.isCurrent;
+                  const prState = branch.pr?.state;
+                  
+                  return (
+                    <span key={branch.branchName} className="flex items-center gap-1">
+                      <ArrowRight className="h-3 w-3 text-muted-foreground" />
+                      {branch.pr ? (
+                        <Link 
+                          to={`/${owner}/${repo}/pull/${branch.pr.number}`}
+                          className={`px-1.5 py-0.5 rounded flex items-center gap-1 ${
+                            isCurrentPR 
+                              ? 'bg-primary text-primary-foreground font-medium' 
+                              : prState === 'merged'
+                                ? 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
+                                : prState === 'closed'
+                                  ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                                  : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                          }`}
+                        >
+                          {prState === 'merged' && <GitMerge className="h-3 w-3" />}
+                          {prState === 'open' && <GitPullRequest className="h-3 w-3" />}
+                          {prState === 'closed' && <Circle className="h-3 w-3" />}
+                          #{branch.pr.number}
+                        </Link>
+                      ) : (
+                        <code className="bg-muted px-1.5 py-0.5 rounded text-muted-foreground">
+                          {branch.branchName}
+                        </code>
+                      )}
+                    </span>
+                  );
+                })}
+              </div>
+              <p className="text-xs text-muted-foreground mt-2">
+                Review and merge PRs in order from left to right
+              </p>
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       {/* Tabs */}

--- a/apps/web/src/routes/repo/stacks.tsx
+++ b/apps/web/src/routes/repo/stacks.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { RepoLayout } from './components/repo-layout';
-import { Loading } from '@/components/ui/loading';
+import { Skeleton } from '@/components/ui/loading';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/lib/trpc';
 
@@ -88,14 +88,6 @@ export function StacksPage() {
       });
     }
   };
-
-  if (stacksLoading) {
-    return (
-      <RepoLayout owner={owner!} repo={repo!}>
-        <Loading text="Loading stacks..." />
-      </RepoLayout>
-    );
-  }
 
   return (
     <RepoLayout owner={owner!} repo={repo!}>
@@ -199,7 +191,27 @@ export function StacksPage() {
         )}
 
         {/* Stacks List */}
-        {!stacks || stacks.length === 0 ? (
+        {stacksLoading ? (
+          <div className="grid gap-4">
+            {[1, 2].map((i) => (
+              <Card key={i}>
+                <CardContent className="p-4">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 space-y-2">
+                      <Skeleton className="h-5 w-40" />
+                      <Skeleton className="h-4 w-64" />
+                      <div className="flex items-center gap-4">
+                        <Skeleton className="h-4 w-24" />
+                        <Skeleton className="h-5 w-16" />
+                        <Skeleton className="h-4 w-32" />
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : !stacks || stacks.length === 0 ? (
           <div className="text-center py-12 text-muted-foreground">
             <Layers className="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p className="text-lg font-medium">No stacks found</p>

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -65,3 +65,11 @@ export {
   getWorkflowRunWithDetails,
   type WorkflowRunWithJobs,
 } from './workflow';
+
+// Stack models (stacked diffs)
+export {
+  stackModel,
+  stackBranchModel,
+  type StackBranchWithPR,
+  type StackWithDetails,
+} from './stack';

--- a/src/db/models/stack.ts
+++ b/src/db/models/stack.ts
@@ -1,0 +1,420 @@
+import { eq, and, desc, asc } from 'drizzle-orm';
+import { getDb } from '../index';
+import {
+  stacks,
+  stackBranches,
+  pullRequests,
+  type Stack,
+  type NewStack,
+  type StackBranch,
+  type NewStackBranch,
+  type PullRequest,
+} from '../schema';
+import { user } from '../auth-schema';
+
+// Author type from better-auth user table
+type Author = {
+  id: string;
+  name: string;
+  email: string;
+  username: string | null;
+  image: string | null;
+  avatarUrl: string | null;
+};
+
+// Stack branch with optional PR info
+export type StackBranchWithPR = StackBranch & {
+  pr?: {
+    id: string;
+    number: number;
+    title: string;
+    state: 'open' | 'closed' | 'merged';
+  } | null;
+};
+
+// Full stack with branches and author
+export type StackWithDetails = Stack & {
+  author: Author;
+  branches: StackBranchWithPR[];
+};
+
+export const stackModel = {
+  /**
+   * Find a stack by ID
+   */
+  async findById(id: string): Promise<Stack | undefined> {
+    const db = getDb();
+    const [stack] = await db
+      .select()
+      .from(stacks)
+      .where(eq(stacks.id, id));
+    return stack;
+  },
+
+  /**
+   * Find a stack by repo and name
+   */
+  async findByRepoAndName(
+    repoId: string,
+    name: string
+  ): Promise<Stack | undefined> {
+    const db = getDb();
+    const [stack] = await db
+      .select()
+      .from(stacks)
+      .where(and(eq(stacks.repoId, repoId), eq(stacks.name, name)));
+    return stack;
+  },
+
+  /**
+   * Find a stack with full details (author, branches, PRs)
+   */
+  async findWithDetails(id: string): Promise<StackWithDetails | undefined> {
+    const db = getDb();
+    
+    // Get stack with author
+    const stackResult = await db
+      .select()
+      .from(stacks)
+      .innerJoin(user, eq(stacks.authorId, user.id))
+      .where(eq(stacks.id, id));
+
+    if (stackResult.length === 0) return undefined;
+
+    const stack = stackResult[0].stacks;
+    const author = {
+      id: stackResult[0].user.id,
+      name: stackResult[0].user.name,
+      email: stackResult[0].user.email,
+      username: stackResult[0].user.username,
+      image: stackResult[0].user.image,
+      avatarUrl: stackResult[0].user.avatarUrl,
+    };
+
+    // Get branches with PRs
+    const branchesResult = await db
+      .select({
+        branch: stackBranches,
+        pr: {
+          id: pullRequests.id,
+          number: pullRequests.number,
+          title: pullRequests.title,
+          state: pullRequests.state,
+        },
+      })
+      .from(stackBranches)
+      .leftJoin(pullRequests, eq(stackBranches.prId, pullRequests.id))
+      .where(eq(stackBranches.stackId, id))
+      .orderBy(asc(stackBranches.position));
+
+    const branches: StackBranchWithPR[] = branchesResult.map((r) => ({
+      ...r.branch,
+      pr: r.pr,
+    }));
+
+    return {
+      ...stack,
+      author,
+      branches,
+    };
+  },
+
+  /**
+   * List stacks by repo
+   */
+  async listByRepo(
+    repoId: string,
+    options: { limit?: number; offset?: number } = {}
+  ): Promise<Stack[]> {
+    const db = getDb();
+    let query = db
+      .select()
+      .from(stacks)
+      .where(eq(stacks.repoId, repoId))
+      .orderBy(desc(stacks.updatedAt));
+
+    if (options.limit) {
+      query = query.limit(options.limit) as typeof query;
+    }
+
+    if (options.offset) {
+      query = query.offset(options.offset) as typeof query;
+    }
+
+    return query;
+  },
+
+  /**
+   * List stacks by repo with branch counts
+   */
+  async listByRepoWithCounts(
+    repoId: string
+  ): Promise<(Stack & { branchCount: number })[]> {
+    const db = getDb();
+    
+    const stacksList = await db
+      .select()
+      .from(stacks)
+      .where(eq(stacks.repoId, repoId))
+      .orderBy(desc(stacks.updatedAt));
+
+    // Get branch counts for each stack
+    const result = await Promise.all(
+      stacksList.map(async (stack) => {
+        const branches = await db
+          .select()
+          .from(stackBranches)
+          .where(eq(stackBranches.stackId, stack.id));
+        
+        return {
+          ...stack,
+          branchCount: branches.length,
+        };
+      })
+    );
+
+    return result;
+  },
+
+  /**
+   * Create a new stack
+   */
+  async create(data: NewStack): Promise<Stack> {
+    const db = getDb();
+    const [stack] = await db.insert(stacks).values(data).returning();
+    return stack;
+  },
+
+  /**
+   * Update a stack
+   */
+  async update(
+    id: string,
+    data: Partial<Omit<NewStack, 'id' | 'repoId' | 'createdAt'>>
+  ): Promise<Stack | undefined> {
+    const db = getDb();
+    const [stack] = await db
+      .update(stacks)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(stacks.id, id))
+      .returning();
+    return stack;
+  },
+
+  /**
+   * Delete a stack (cascades to branches)
+   */
+  async delete(id: string): Promise<boolean> {
+    const db = getDb();
+    const result = await db
+      .delete(stacks)
+      .where(eq(stacks.id, id))
+      .returning();
+    return result.length > 0;
+  },
+};
+
+export const stackBranchModel = {
+  /**
+   * Find a branch by ID
+   */
+  async findById(id: string): Promise<StackBranch | undefined> {
+    const db = getDb();
+    const [branch] = await db
+      .select()
+      .from(stackBranches)
+      .where(eq(stackBranches.id, id));
+    return branch;
+  },
+
+  /**
+   * List branches for a stack (ordered by position)
+   */
+  async listByStack(stackId: string): Promise<StackBranch[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(stackBranches)
+      .where(eq(stackBranches.stackId, stackId))
+      .orderBy(asc(stackBranches.position));
+  },
+
+  /**
+   * Add a branch to a stack
+   */
+  async add(
+    stackId: string,
+    branchName: string,
+    position?: number
+  ): Promise<StackBranch> {
+    const db = getDb();
+
+    // If no position specified, add to the end
+    if (position === undefined) {
+      const existing = await this.listByStack(stackId);
+      position = existing.length;
+    }
+
+    const [branch] = await db
+      .insert(stackBranches)
+      .values({
+        stackId,
+        branchName,
+        position,
+      })
+      .returning();
+
+    // Update the stack's updatedAt
+    await db
+      .update(stacks)
+      .set({ updatedAt: new Date() })
+      .where(eq(stacks.id, stackId));
+
+    return branch;
+  },
+
+  /**
+   * Remove a branch from a stack
+   */
+  async remove(stackId: string, branchName: string): Promise<boolean> {
+    const db = getDb();
+    
+    // Find and delete the branch
+    const result = await db
+      .delete(stackBranches)
+      .where(
+        and(
+          eq(stackBranches.stackId, stackId),
+          eq(stackBranches.branchName, branchName)
+        )
+      )
+      .returning();
+
+    if (result.length === 0) return false;
+
+    // Reorder remaining branches to fill the gap
+    const remaining = await this.listByStack(stackId);
+    for (let i = 0; i < remaining.length; i++) {
+      if (remaining[i].position !== i) {
+        await db
+          .update(stackBranches)
+          .set({ position: i })
+          .where(eq(stackBranches.id, remaining[i].id));
+      }
+    }
+
+    // Update the stack's updatedAt
+    await db
+      .update(stacks)
+      .set({ updatedAt: new Date() })
+      .where(eq(stacks.id, stackId));
+
+    return true;
+  },
+
+  /**
+   * Reorder branches in a stack
+   */
+  async reorder(stackId: string, branchNames: string[]): Promise<void> {
+    const db = getDb();
+    
+    // Update positions based on new order
+    for (let i = 0; i < branchNames.length; i++) {
+      await db
+        .update(stackBranches)
+        .set({ position: i })
+        .where(
+          and(
+            eq(stackBranches.stackId, stackId),
+            eq(stackBranches.branchName, branchNames[i])
+          )
+        );
+    }
+
+    // Update the stack's updatedAt
+    await db
+      .update(stacks)
+      .set({ updatedAt: new Date() })
+      .where(eq(stacks.id, stackId));
+  },
+
+  /**
+   * Link a PR to a stack branch
+   */
+  async linkPR(stackId: string, branchName: string, prId: string): Promise<void> {
+    const db = getDb();
+    
+    await db
+      .update(stackBranches)
+      .set({ prId })
+      .where(
+        and(
+          eq(stackBranches.stackId, stackId),
+          eq(stackBranches.branchName, branchName)
+        )
+      );
+
+    // Also update the PR to reference this stack
+    await db
+      .update(pullRequests)
+      .set({ stackId })
+      .where(eq(pullRequests.id, prId));
+  },
+
+  /**
+   * Unlink a PR from a stack branch
+   */
+  async unlinkPR(stackId: string, branchName: string): Promise<void> {
+    const db = getDb();
+    
+    // Get the branch to find the PR ID
+    const [branch] = await db
+      .select()
+      .from(stackBranches)
+      .where(
+        and(
+          eq(stackBranches.stackId, stackId),
+          eq(stackBranches.branchName, branchName)
+        )
+      );
+
+    if (branch?.prId) {
+      // Remove stack reference from PR
+      await db
+        .update(pullRequests)
+        .set({ stackId: null })
+        .where(eq(pullRequests.id, branch.prId));
+    }
+
+    // Remove PR reference from branch
+    await db
+      .update(stackBranches)
+      .set({ prId: null })
+      .where(
+        and(
+          eq(stackBranches.stackId, stackId),
+          eq(stackBranches.branchName, branchName)
+        )
+      );
+  },
+
+  /**
+   * Find a stack branch by its associated PR
+   */
+  async findByPR(prId: string): Promise<(StackBranch & { stack: Stack }) | undefined> {
+    const db = getDb();
+    
+    const result = await db
+      .select()
+      .from(stackBranches)
+      .innerJoin(stacks, eq(stackBranches.stackId, stacks.id))
+      .where(eq(stackBranches.prId, prId));
+
+    if (result.length === 0) return undefined;
+
+    return {
+      ...result[0].stack_branches,
+      stack: result[0].stacks,
+    };
+  },
+};


### PR DESCRIPTION
## Summary

This PR makes stacks a first-class feature by integrating them with Pull Requests, fixing performance issues, and providing a seamless UX for stacked diffs.

### Performance Fixes
- Fixed slow loading of stacks page on repos with no data by implementing lazy initialization
- Replaced blocking spinner with skeleton loaders for better perceived performance

### Stacks/PRs Integration

**Problem**: Stacks and PRs were completely disconnected - stacks were stored locally in `.git/stacks/`, PRs knew nothing about stacks, and users had to manually create PRs for each branch.

**Solution**: 

1. **Database Schema**: Added `stacks` and `stack_branches` tables, plus `stackId` FK on `pull_requests`

2. **New Stack Model**: Full CRUD operations with PR linking support

3. **Submit Stack Feature**: One-click button to create properly chained PRs:
   - Branch 1 → targets base branch (e.g., `main`)
   - Branch 2 → targets Branch 1
   - Branch 3 → targets Branch 2
   - Auto-generates PR body with stack context

4. **Stack Context in PRs**: When viewing a PR that's part of a stack, reviewers see:
   - Which stack it belongs to
   - Visual flow of all PRs in the stack
   - Which PRs are merged/open/closed
   - Links to navigate between related PRs

### Files Changed

- `src/db/schema.ts` - New stacks/stack_branches tables, stackId on PRs
- `src/db/models/stack.ts` - New model for stack operations
- `src/api/trpc/routers/stacks.ts` - Rewritten to use database + submit endpoint
- `src/api/trpc/routers/pulls.ts` - Returns stack context with PR
- `apps/web/src/routes/repo/stacks.tsx` - Skeleton loaders
- `apps/web/src/routes/repo/stack-detail.tsx` - PR status, submit button
- `apps/web/src/routes/repo/pull-detail.tsx` - Stack context visualization

### Screenshots

The stack detail page now shows PR status for each branch and a "Submit Stack" button:
- Branches without PRs show "No PR" badge
- Branches with PRs show their status (open/merged/closed)
- Submit creates all missing PRs with proper targeting

The PR detail page shows stack context:
- Visual flow: `main → #1 → #2 → #3`
- Current PR highlighted
- Click any PR number to navigate