### PR TITLE
feat: add Graphite-style PR inbox for code review management

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,7 @@ import {
   // Platform commands
   handlePr,
   handleIssue,
+  handleInbox,
   // Issue tracking (Linear-inspired) - also exports handleCycle
   handleCycle,
   // Platform management
@@ -240,6 +241,11 @@ Platform Commands:
   pr review [<number>]  AI code review using CodeRabbit
   pr review-status      Check CodeRabbit configuration
   
+  inbox                 PR inbox - stay on top of reviews
+  inbox review          Show PRs awaiting your review
+  inbox mine            Show your open PRs
+  inbox participated    Show PRs you've participated in
+  
   issue create <title>  Create new issue
   issue list            List issues
   issue view <number>   View issue details
@@ -404,7 +410,7 @@ const COMMANDS = [
   // Server
   'serve',
   // Platform commands
-  'pr', 'issue',
+  'pr', 'issue', 'inbox',
   // Platform management
   'up', 'down', 'platform-status',
   // Authentication
@@ -954,6 +960,17 @@ function main(): void {
 
       case 'issue':
         handleIssue(args.slice(args.indexOf('issue') + 1)).catch((error: Error) => {
+          if (error instanceof TsgitError) {
+            console.error((error as TsgitError).format());
+          } else {
+            console.error(`error: ${error.message}`);
+          }
+          process.exit(1);
+        });
+        return; // Exit main() to let async handle complete
+
+      case 'inbox':
+        handleInbox(args.slice(args.indexOf('inbox') + 1)).catch((error: Error) => {
           if (error instanceof TsgitError) {
             console.error((error as TsgitError).format());
           } else {

--- a/src/commands/inbox.ts
+++ b/src/commands/inbox.ts
@@ -1,0 +1,535 @@
+/**
+ * Inbox Command
+ *
+ * A Graphite-style PR inbox for staying on top of code reviews.
+ * Shows PRs awaiting your review, your open PRs, and PRs you've participated in.
+ *
+ * Usage:
+ *   wit inbox              Show inbox summary and quick view
+ *   wit inbox review       Show PRs awaiting your review
+ *   wit inbox mine         Show your open PRs
+ *   wit inbox participated Show PRs you've commented/reviewed
+ *   wit inbox summary      Show counts for each section
+ */
+
+import { getApiClient, ApiError, getServerUrl, type InboxPullRequest } from '../api/client';
+
+const colors = {
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s: string) => `\x1b[33m${s}\x1b[0m`,
+  cyan: (s: string) => `\x1b[36m${s}\x1b[0m`,
+  red: (s: string) => `\x1b[31m${s}\x1b[0m`,
+  magenta: (s: string) => `\x1b[35m${s}\x1b[0m`,
+  dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
+  blue: (s: string) => `\x1b[34m${s}\x1b[0m`,
+  bgRed: (s: string) => `\x1b[41m${s}\x1b[0m`,
+  bgGreen: (s: string) => `\x1b[42m${s}\x1b[0m`,
+  bgYellow: (s: string) => `\x1b[43m${s}\x1b[0m`,
+};
+
+export const INBOX_HELP = `
+wit inbox - PR Inbox (Graphite-style)
+
+Stay on top of every PR and review request in one unified inbox.
+
+Usage: wit inbox [command] [options]
+
+Commands:
+  (none)        Show full inbox with all sections
+  review        Show PRs awaiting your review
+  mine          Show your open PRs
+  participated  Show PRs you've participated in
+  summary       Show counts for each section
+
+Options:
+  -h, --help    Show this help message
+  --limit <n>   Limit number of results (default: 10)
+  --all         Show all results (no limit)
+  --json        Output as JSON
+
+Sections:
+  ${colors.yellow('Review Requested')}  PRs where you've been asked to review
+  ${colors.cyan('Your PRs')}           Your open PRs (awaiting reviews or ready to merge)
+  ${colors.magenta('Participated')}       PRs you've commented on or reviewed
+
+Examples:
+  wit inbox                  Show full inbox
+  wit inbox review           Show PRs needing your review
+  wit inbox mine             Show your open PRs
+  wit inbox summary          Quick count of each section
+  wit inbox --json           Get inbox as JSON
+`;
+
+/**
+ * Parse arguments for inbox command
+ */
+function parseArgs(args: string[]): {
+  flags: Record<string, string | boolean>;
+  positional: string[];
+} {
+  const flags: Record<string, string | boolean> = {};
+  const positional: string[] = [];
+
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2);
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        flags[key] = args[i + 1];
+        i += 2;
+      } else {
+        flags[key] = true;
+        i++;
+      }
+    } else if (arg.startsWith('-') && arg.length === 2) {
+      const key = arg.slice(1);
+      const keyMap: Record<string, string> = {
+        h: 'help',
+        n: 'limit',
+        a: 'all',
+      };
+      const mappedKey = keyMap[key] || key;
+      if (i + 1 < args.length && !args[i + 1].startsWith('-')) {
+        flags[mappedKey] = args[i + 1];
+        i += 2;
+      } else {
+        flags[mappedKey] = true;
+        i++;
+      }
+    } else {
+      positional.push(arg);
+      i++;
+    }
+  }
+
+  return { flags, positional };
+}
+
+/**
+ * Format a relative time string
+ */
+function formatRelativeTime(date: Date | string): string {
+  const now = new Date();
+  const then = new Date(date);
+  const diffMs = now.getTime() - then.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  return then.toLocaleDateString();
+}
+
+/**
+ * Get CI status icon
+ */
+function getCiStatusIcon(status: string | null | undefined): string {
+  switch (status) {
+    case 'success':
+      return colors.green('✓');
+    case 'failure':
+      return colors.red('✗');
+    case 'pending':
+      return colors.yellow('○');
+    default:
+      return colors.dim('·');
+  }
+}
+
+/**
+ * Get review status icon
+ */
+function getReviewStatusIcon(state: string | null | undefined): string {
+  switch (state) {
+    case 'approved':
+      return colors.green('✓');
+    case 'changes_requested':
+      return colors.red('!');
+    case 'commented':
+      return colors.yellow('●');
+    case 'pending':
+      return colors.dim('○');
+    default:
+      return colors.dim('·');
+  }
+}
+
+/**
+ * Format a single PR for display
+ */
+function formatPr(pr: InboxPullRequest, showRepo: boolean = true): string {
+  const stateIcon =
+    pr.state === 'open'
+      ? colors.green('●')
+      : pr.state === 'merged'
+        ? colors.magenta('●')
+        : colors.red('●');
+
+  const ciIcon = getCiStatusIcon(pr.ciStatus);
+  const reviewIcon = getReviewStatusIcon(pr.reviewState);
+
+  const repoName = showRepo ? colors.dim(`${pr.repo.name}`) : '';
+  const authorName = pr.author?.username || pr.author?.name || 'unknown';
+  const time = formatRelativeTime(pr.updatedAt);
+
+  // Build labels string
+  const labelStr = pr.labels?.length
+    ? ' ' + pr.labels.map((l) => colors.cyan(`[${l.name}]`)).join(' ')
+    : '';
+
+  // Draft indicator
+  const draftStr = pr.isDraft ? colors.dim(' (draft)') : '';
+
+  return `${stateIcon} ${ciIcon} ${reviewIcon} #${pr.number} ${pr.title}${draftStr}${labelStr}
+   ${repoName ? repoName + ' · ' : ''}${colors.dim(authorName)} · ${colors.dim(time)}`;
+}
+
+/**
+ * Main handler for inbox command
+ */
+export async function handleInbox(args: string[]): Promise<void> {
+  const { flags, positional } = parseArgs(args);
+
+  if (flags.help) {
+    console.log(INBOX_HELP);
+    return;
+  }
+
+  const subcommand = positional[0];
+  const limit = flags.all ? 100 : parseInt(flags.limit as string, 10) || 10;
+
+  try {
+    const api = getApiClient();
+
+    switch (subcommand) {
+      case 'review':
+        await showAwaitingReview(api, { limit, json: !!flags.json });
+        break;
+      case 'mine':
+        await showMyPrs(api, { limit, json: !!flags.json });
+        break;
+      case 'participated':
+        await showParticipated(api, { limit, json: !!flags.json });
+        break;
+      case 'summary':
+        await showSummary(api, { json: !!flags.json });
+        break;
+      default:
+        // Show full inbox
+        await showFullInbox(api, { limit, json: !!flags.json });
+    }
+  } catch (error) {
+    if (error instanceof ApiError) {
+      console.error(colors.red('error: ') + error.message);
+      if (error.status === 0) {
+        console.error(colors.dim('hint: Start the server with: wit serve'));
+        console.error(colors.dim('      Or authenticate with: wit github login'));
+      }
+      process.exit(1);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Show full inbox with all sections
+ */
+async function showFullInbox(
+  api: ReturnType<typeof getApiClient>,
+  options: { limit: number; json: boolean }
+): Promise<void> {
+  // Fetch all sections in parallel
+  const [summary, awaitingReview, myPrs, participated] = await Promise.all([
+    api.inbox.summary(),
+    api.inbox.awaitingReview({ limit: options.limit }),
+    api.inbox.myPrs({ limit: options.limit }),
+    api.inbox.participated({ limit: options.limit }),
+  ]);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify({ summary, awaitingReview, myPrs, participated }, null, 2)
+    );
+    return;
+  }
+
+  // Header
+  console.log();
+  console.log(colors.bold('  PR Inbox'));
+  console.log(colors.dim('  ─'.repeat(30)));
+  console.log();
+
+  // Summary bar
+  const reviewBadge =
+    summary.awaitingReview > 0
+      ? colors.yellow(` ${summary.awaitingReview} `)
+      : colors.dim(' 0 ');
+  const myPrsBadge =
+    summary.myPrsOpen > 0
+      ? colors.cyan(` ${summary.myPrsOpen} `)
+      : colors.dim(' 0 ');
+  const participatedBadge =
+    summary.participated > 0
+      ? colors.magenta(` ${summary.participated} `)
+      : colors.dim(' 0 ');
+
+  console.log(
+    `  ${colors.yellow('Review')}${reviewBadge}  ${colors.cyan('Mine')}${myPrsBadge}  ${colors.magenta('Participated')}${participatedBadge}`
+  );
+  console.log();
+
+  // Review Requested section
+  if (awaitingReview.length > 0) {
+    console.log(
+      colors.yellow(colors.bold(`  Review Requested (${summary.awaitingReview})`))
+    );
+    console.log(colors.dim('  ' + '─'.repeat(40)));
+    for (const pr of awaitingReview.slice(0, 5)) {
+      console.log('  ' + formatPr(pr).split('\n').join('\n  '));
+    }
+    if (summary.awaitingReview > 5) {
+      console.log(
+        colors.dim(`  ... and ${summary.awaitingReview - 5} more (wit inbox review)`)
+      );
+    }
+    console.log();
+  }
+
+  // Your PRs section
+  if (myPrs.length > 0) {
+    console.log(colors.cyan(colors.bold(`  Your PRs (${summary.myPrsOpen})`)));
+    console.log(colors.dim('  ' + '─'.repeat(40)));
+    for (const pr of myPrs.slice(0, 5)) {
+      console.log('  ' + formatPr(pr, false).split('\n').join('\n  '));
+    }
+    if (summary.myPrsOpen > 5) {
+      console.log(
+        colors.dim(`  ... and ${summary.myPrsOpen - 5} more (wit inbox mine)`)
+      );
+    }
+    console.log();
+  }
+
+  // Participated section
+  if (participated.length > 0) {
+    console.log(colors.magenta(colors.bold(`  Participated (${summary.participated})`)));
+    console.log(colors.dim('  ' + '─'.repeat(40)));
+    for (const pr of participated.slice(0, 5)) {
+      console.log('  ' + formatPr(pr).split('\n').join('\n  '));
+    }
+    if (summary.participated > 5) {
+      console.log(
+        colors.dim(`  ... and ${summary.participated - 5} more (wit inbox participated)`)
+      );
+    }
+    console.log();
+  }
+
+  // Empty state
+  if (
+    awaitingReview.length === 0 &&
+    myPrs.length === 0 &&
+    participated.length === 0
+  ) {
+    console.log(colors.dim('  No pull requests to show.'));
+    console.log(colors.dim('  Create a PR with: wit pr create'));
+    console.log();
+  }
+
+  // Footer with tips
+  console.log(colors.dim('  ─'.repeat(30)));
+  console.log(
+    colors.dim('  Tip: Use ') +
+      'wit inbox review' +
+      colors.dim(' to focus on PRs needing your review')
+  );
+  console.log();
+}
+
+/**
+ * Show PRs awaiting review
+ */
+async function showAwaitingReview(
+  api: ReturnType<typeof getApiClient>,
+  options: { limit: number; json: boolean }
+): Promise<void> {
+  const prs = await api.inbox.awaitingReview({ limit: options.limit });
+
+  if (options.json) {
+    console.log(JSON.stringify(prs, null, 2));
+    return;
+  }
+
+  console.log();
+  console.log(colors.yellow(colors.bold('  Review Requested')));
+  console.log(colors.dim('  PRs waiting for your review'));
+  console.log(colors.dim('  ' + '─'.repeat(40)));
+  console.log();
+
+  if (prs.length === 0) {
+    console.log(colors.green('  ✓ No PRs waiting for your review!'));
+    console.log(colors.dim('  You\'re all caught up.'));
+    console.log();
+    return;
+  }
+
+  for (const pr of prs) {
+    console.log('  ' + formatPr(pr).split('\n').join('\n  '));
+    console.log();
+  }
+
+  console.log(colors.dim('  ─'.repeat(40)));
+  console.log(
+    colors.dim('  Review a PR: ') + 'wit pr view <number>' + colors.dim(' or ') + 'wit pr checkout <number>'
+  );
+  console.log();
+}
+
+/**
+ * Show user's own PRs
+ */
+async function showMyPrs(
+  api: ReturnType<typeof getApiClient>,
+  options: { limit: number; json: boolean }
+): Promise<void> {
+  const prs = await api.inbox.myPrs({ limit: options.limit });
+
+  if (options.json) {
+    console.log(JSON.stringify(prs, null, 2));
+    return;
+  }
+
+  console.log();
+  console.log(colors.cyan(colors.bold('  Your Pull Requests')));
+  console.log(colors.dim('  Open PRs you\'ve created'));
+  console.log(colors.dim('  ' + '─'.repeat(40)));
+  console.log();
+
+  if (prs.length === 0) {
+    console.log(colors.dim('  No open PRs.'));
+    console.log(colors.dim('  Create one with: wit pr create'));
+    console.log();
+    return;
+  }
+
+  for (const pr of prs) {
+    // Show review summary for your PRs
+    const reviewSummary = getReviewSummary(pr);
+    console.log('  ' + formatPr(pr, false).split('\n').join('\n  '));
+    if (reviewSummary) {
+      console.log('   ' + reviewSummary);
+    }
+    console.log();
+  }
+
+  console.log(colors.dim('  ─'.repeat(40)));
+  console.log(colors.dim('  Icons: ') + colors.green('✓') + ' CI passed  ' + colors.red('✗') + ' CI failed  ' + colors.yellow('○') + ' Pending');
+  console.log();
+}
+
+/**
+ * Show PRs user has participated in
+ */
+async function showParticipated(
+  api: ReturnType<typeof getApiClient>,
+  options: { limit: number; json: boolean }
+): Promise<void> {
+  const prs = await api.inbox.participated({ limit: options.limit });
+
+  if (options.json) {
+    console.log(JSON.stringify(prs, null, 2));
+    return;
+  }
+
+  console.log();
+  console.log(colors.magenta(colors.bold('  Participated')));
+  console.log(colors.dim('  PRs you\'ve reviewed or commented on'));
+  console.log(colors.dim('  ' + '─'.repeat(40)));
+  console.log();
+
+  if (prs.length === 0) {
+    console.log(colors.dim('  No participated PRs.'));
+    console.log(colors.dim('  Review a PR to see it here.'));
+    console.log();
+    return;
+  }
+
+  for (const pr of prs) {
+    console.log('  ' + formatPr(pr).split('\n').join('\n  '));
+    console.log();
+  }
+}
+
+/**
+ * Show summary counts
+ */
+async function showSummary(
+  api: ReturnType<typeof getApiClient>,
+  options: { json: boolean }
+): Promise<void> {
+  const summary = await api.inbox.summary();
+
+  if (options.json) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  console.log();
+  console.log(colors.bold('  Inbox Summary'));
+  console.log(colors.dim('  ' + '─'.repeat(30)));
+  console.log();
+
+  const reviewLabel = summary.awaitingReview === 1 ? 'PR' : 'PRs';
+  const myLabel = summary.myPrsOpen === 1 ? 'PR' : 'PRs';
+  const partLabel = summary.participated === 1 ? 'PR' : 'PRs';
+
+  console.log(
+    `  ${colors.yellow('●')} Review Requested:  ${colors.bold(summary.awaitingReview.toString())} ${reviewLabel}`
+  );
+  console.log(
+    `  ${colors.cyan('●')} Your Open PRs:     ${colors.bold(summary.myPrsOpen.toString())} ${myLabel}`
+  );
+  console.log(
+    `  ${colors.magenta('●')} Participated:      ${colors.bold(summary.participated.toString())} ${partLabel}`
+  );
+  console.log();
+
+  // Action suggestion
+  if (summary.awaitingReview > 0) {
+    console.log(
+      colors.dim('  ') +
+        colors.yellow('→') +
+        ` ${summary.awaitingReview} ${reviewLabel} awaiting your review`
+    );
+  } else {
+    console.log(colors.dim('  ') + colors.green('✓') + ' No pending reviews');
+  }
+  console.log();
+}
+
+/**
+ * Get a review summary string for a PR
+ */
+function getReviewSummary(pr: InboxPullRequest): string | null {
+  if (!pr.reviewState) return null;
+
+  switch (pr.reviewState) {
+    case 'approved':
+      return colors.green('✓ Approved - ready to merge');
+    case 'changes_requested':
+      return colors.red('! Changes requested');
+    case 'commented':
+      return colors.yellow('● Feedback received');
+    case 'pending':
+      return colors.dim('○ Awaiting review');
+    default:
+      return null;
+  }
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -80,6 +80,7 @@ export { COMMAND_HELP, formatCommandHelp, printCommandHelp, hasHelpFlag } from '
 // Platform commands (CLI extensions)
 export { handlePr, PR_HELP } from './pr';
 export { handleIssue, ISSUE_HELP } from './issue';
+export { handleInbox, INBOX_HELP } from './inbox';
 
 // Issue tracking (Linear-inspired) - cycle/sprint management
 export { handleCycle } from './cycle';

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -27,6 +27,9 @@ export {
   prReviewModel,
   prCommentModel,
   prLabelModel,
+  prReviewerModel,
+  inboxModel,
+  type InboxPr,
 } from './pull-request';
 
 // Issue models

--- a/tests/integration/inbox.test.ts
+++ b/tests/integration/inbox.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Inbox Integration Tests
+ * 
+ * Tests for the PR inbox feature including:
+ * - Review request management
+ * - Inbox summary
+ * - PRs awaiting review
+ * - User's own PRs
+ * - Participated PRs
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  startTestServer,
+  stopTestServer,
+  createTestClient,
+  createAuthenticatedClient,
+  uniqueUsername,
+  uniqueEmail,
+  uniqueRepoName,
+} from './setup';
+
+describe('PR Inbox', () => {
+  let authorToken: string;
+  let authorId: string;
+  let authorUsername: string;
+  
+  let reviewerToken: string;
+  let reviewerId: string;
+  let reviewerUsername: string;
+  
+  let repoId: string;
+  let prId: string;
+
+  beforeAll(async () => {
+    await startTestServer();
+
+    const api = createTestClient();
+
+    // Create author user
+    authorUsername = uniqueUsername('inbox-author');
+    const authorResult = await api.auth.register.mutate({
+      username: authorUsername,
+      email: uniqueEmail('inbox-author'),
+      password: 'password123',
+      name: 'PR Author',
+    });
+    authorToken = authorResult.sessionId;
+    authorId = authorResult.user.id;
+
+    // Create reviewer user
+    reviewerUsername = uniqueUsername('inbox-reviewer');
+    const reviewerResult = await api.auth.register.mutate({
+      username: reviewerUsername,
+      email: uniqueEmail('inbox-reviewer'),
+      password: 'password123',
+      name: 'PR Reviewer',
+    });
+    reviewerToken = reviewerResult.sessionId;
+    reviewerId = reviewerResult.user.id;
+
+    // Create a repository as the author
+    const authApi = createAuthenticatedClient(authorToken);
+    const repo = await authApi.repos.create.mutate({
+      name: uniqueRepoName('inbox-test'),
+      description: 'Repo for inbox tests',
+      isPrivate: false,
+    });
+    repoId = repo.id;
+  }, 30000);
+
+  afterAll(async () => {
+    await stopTestServer();
+  });
+
+  describe('Inbox Summary', () => {
+    it('returns summary counts for authenticated user', async () => {
+      const authApi = createAuthenticatedClient(authorToken);
+
+      const summary = await authApi.pulls.inboxSummary.query();
+
+      expect(summary).toHaveProperty('awaitingReview');
+      expect(summary).toHaveProperty('myPrsOpen');
+      expect(summary).toHaveProperty('participated');
+      expect(typeof summary.awaitingReview).toBe('number');
+      expect(typeof summary.myPrsOpen).toBe('number');
+      expect(typeof summary.participated).toBe('number');
+    });
+
+    it('initially shows zero counts for new user', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      const summary = await reviewerApi.pulls.inboxSummary.query();
+
+      // New user with no PRs or review requests
+      expect(summary.awaitingReview).toBe(0);
+      expect(summary.myPrsOpen).toBe(0);
+      expect(summary.participated).toBe(0);
+    });
+  });
+
+  describe('PR Creation and Review Requests', () => {
+    it('creates a PR and shows it in author\'s inbox', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+
+      // Create a PR
+      const pr = await authorApi.pulls.create.mutate({
+        repoId,
+        title: 'Test PR for inbox',
+        body: 'This PR tests the inbox feature',
+        sourceBranch: 'feature/inbox-test',
+        targetBranch: 'main',
+        headSha: 'abc123def456',
+        baseSha: 'def456abc123',
+      });
+
+      prId = pr.id;
+      expect(pr.id).toBeDefined();
+      expect(pr.number).toBe(1);
+
+      // Check author's inbox shows the PR
+      const myPrs = await authorApi.pulls.inboxMyPrs.query();
+      expect(myPrs.length).toBeGreaterThanOrEqual(1);
+      expect(myPrs.some(p => p.id === prId)).toBe(true);
+
+      // Check summary updated
+      const summary = await authorApi.pulls.inboxSummary.query();
+      expect(summary.myPrsOpen).toBeGreaterThanOrEqual(1);
+    });
+
+    it('requests a review and shows in reviewer\'s inbox', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      // Request review from reviewer
+      const result = await authorApi.pulls.requestReview.mutate({
+        prId,
+        reviewerId,
+      });
+      expect(result).toBeDefined();
+
+      // Check reviewer's inbox shows the PR awaiting review
+      const awaitingReview = await reviewerApi.pulls.inboxAwaitingReview.query();
+      expect(awaitingReview.length).toBeGreaterThanOrEqual(1);
+      expect(awaitingReview.some(p => p.id === prId)).toBe(true);
+
+      // Check reviewer's summary
+      const summary = await reviewerApi.pulls.inboxSummary.query();
+      expect(summary.awaitingReview).toBeGreaterThanOrEqual(1);
+    });
+
+    it('lists reviewers for a PR', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+
+      const reviewers = await authorApi.pulls.reviewers.query({ prId });
+      expect(reviewers.length).toBeGreaterThanOrEqual(1);
+      expect(reviewers.some(r => r.userId === reviewerId)).toBe(true);
+      expect(reviewers[0].state).toBe('pending');
+    });
+  });
+
+  describe('Review Submission', () => {
+    it('marks review as completed when review is submitted', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+      const authorApi = createAuthenticatedClient(authorToken);
+
+      // Submit a review
+      const review = await reviewerApi.pulls.addReview.mutate({
+        prId,
+        state: 'approved',
+        body: 'LGTM!',
+        commitSha: 'abc123def456',
+      });
+      expect(review.id).toBeDefined();
+      expect(review.state).toBe('approved');
+
+      // Check reviewer's pending count decreased
+      // Note: The event handler should mark the review as completed
+      const reviewers = await authorApi.pulls.reviewers.query({ prId });
+      const reviewerEntry = reviewers.find(r => r.userId === reviewerId);
+      expect(reviewerEntry?.state).toBe('completed');
+    });
+
+    it('shows PR in participated after reviewing', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      const participated = await reviewerApi.pulls.inboxParticipated.query();
+      // Note: participated should include PRs where user reviewed but isn't the author
+      // The exact behavior depends on the query logic
+      expect(Array.isArray(participated)).toBe(true);
+    });
+  });
+
+  describe('Review Request Management', () => {
+    it('removes a review request', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+      const api = createTestClient();
+
+      // Create another reviewer
+      const reviewer2Username = uniqueUsername('inbox-reviewer2');
+      const reviewer2Result = await api.auth.register.mutate({
+        username: reviewer2Username,
+        email: uniqueEmail('inbox-reviewer2'),
+        password: 'password123',
+        name: 'PR Reviewer 2',
+      });
+      const reviewer2Id = reviewer2Result.user.id;
+
+      // Request review
+      await authorApi.pulls.requestReview.mutate({
+        prId,
+        reviewerId: reviewer2Id,
+      });
+
+      // Remove the request
+      const removed = await authorApi.pulls.removeReviewRequest.mutate({
+        prId,
+        reviewerId: reviewer2Id,
+      });
+      expect(removed).toBe(true);
+
+      // Verify removed from reviewers list
+      const reviewers = await authorApi.pulls.reviewers.query({ prId });
+      expect(reviewers.some(r => r.userId === reviewer2Id)).toBe(false);
+    });
+  });
+
+  describe('Inbox Filtering', () => {
+    it('filters awaiting review with limit', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      const limited = await reviewerApi.pulls.inboxAwaitingReview.query({
+        limit: 1,
+      });
+      expect(limited.length).toBeLessThanOrEqual(1);
+    });
+
+    it('filters my PRs with limit and offset', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+
+      const page1 = await authorApi.pulls.inboxMyPrs.query({
+        limit: 5,
+        offset: 0,
+      });
+      expect(Array.isArray(page1)).toBe(true);
+
+      const page2 = await authorApi.pulls.inboxMyPrs.query({
+        limit: 5,
+        offset: 5,
+      });
+      expect(Array.isArray(page2)).toBe(true);
+    });
+
+    it('filters participated by state', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      const openOnly = await reviewerApi.pulls.inboxParticipated.query({
+        state: 'open',
+      });
+      expect(Array.isArray(openOnly)).toBe(true);
+
+      const all = await reviewerApi.pulls.inboxParticipated.query({
+        state: 'all',
+      });
+      expect(Array.isArray(all)).toBe(true);
+    });
+  });
+
+  describe('Inbox Data Enrichment', () => {
+    it('includes author information in inbox PRs', async () => {
+      const reviewerApi = createAuthenticatedClient(reviewerToken);
+
+      // First request a new review to ensure we have data
+      const authorApi = createAuthenticatedClient(authorToken);
+      const newPr = await authorApi.pulls.create.mutate({
+        repoId,
+        title: 'PR with author info',
+        sourceBranch: 'feature/author-test',
+        targetBranch: 'main',
+        headSha: 'xyz789',
+        baseSha: 'abc123',
+      });
+
+      await authorApi.pulls.requestReview.mutate({
+        prId: newPr.id,
+        reviewerId,
+      });
+
+      const awaitingReview = await reviewerApi.pulls.inboxAwaitingReview.query();
+      const pr = awaitingReview.find(p => p.id === newPr.id);
+
+      if (pr) {
+        expect(pr.repo).toBeDefined();
+        expect(pr.repo.name).toBeDefined();
+        expect(pr.author).toBeDefined();
+        expect(pr.labels).toBeDefined();
+        expect(Array.isArray(pr.labels)).toBe(true);
+      }
+    });
+
+    it('includes repository information in inbox PRs', async () => {
+      const authorApi = createAuthenticatedClient(authorToken);
+
+      const myPrs = await authorApi.pulls.inboxMyPrs.query();
+      
+      if (myPrs.length > 0) {
+        const pr = myPrs[0];
+        expect(pr.repo).toBeDefined();
+        expect(pr.repo.id).toBe(repoId);
+        expect(pr.repo.name).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a unified PR inbox feature inspired by [Graphite's inbox](https://graphite.com/features#inbox), allowing users to stay on top of code reviews in one place.

### Features

**Three inbox sections:**
- **Review Requested** - PRs where you've been asked to review
- **Your PRs** - Your open PRs with CI status and review state  
- **Participated** - PRs you've commented on or reviewed

**CLI Command:**
```bash
wit inbox              # Full inbox view
wit inbox review       # PRs awaiting your review
wit inbox mine         # Your open PRs
wit inbox participated # PRs you've participated in
wit inbox summary      # Quick counts
```

**Rich TUI output** showing:
- CI status indicators (✓ success, ✗ failure, ○ pending)
- Review state indicators (✓ approved, ! changes requested, ● commented)
- Labels, author info, and relative timestamps
- Repository context for cross-repo visibility

### Implementation

- **Database**: New `prReviewers` table to track review requests with states (pending, completed, dismissed)
- **Models**: `prReviewerModel` for CRUD operations, `inboxModel` for inbox queries
- **API**: New endpoints for inbox summary, each section, and reviewer management
- **CLI**: New `wit inbox` command with colorful TUI
- **Events**: Updated handlers to persist and complete review requests automatically

### Files Changed

- `src/db/schema.ts` - New `prReviewers` table and enum
- `src/db/models/pull-request.ts` - New `prReviewerModel` and `inboxModel`
- `src/api/trpc/routers/pulls.ts` - Inbox and reviewer API endpoints
- `src/api/client.ts` - Client-side inbox methods
- `src/commands/inbox.ts` - New CLI command
- `src/events/handlers/notifications.ts` - Auto-persist review requests
- `tests/integration/inbox.test.ts` - Integration tests