### PR TITLE
feat(web): add organization features to web app

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,6 +43,7 @@ import { OrgPage } from './routes/org';
 import { OrgSettingsPage } from './routes/org/settings';
 import { OrgMembersPage } from './routes/org/members';
 import { OrgTeamsPage } from './routes/org/teams';
+import { TeamDetailPage } from './routes/org/team-detail';
 import { SearchPage } from './routes/search';
 import { PullsInboxPage } from './routes/pulls';
 import { IssuesInboxPage } from './routes/issues';
@@ -76,6 +77,7 @@ export function App() {
             <Route path="/org/:slug/settings" element={<OrgSettingsPage />} />
             <Route path="/org/:slug/members" element={<OrgMembersPage />} />
             <Route path="/org/:slug/teams" element={<OrgTeamsPage />} />
+            <Route path="/org/:slug/teams/:teamId" element={<TeamDetailPage />} />
 
             {/* User/Org profile */}
             <Route path="/:owner" element={<OwnerPage />} />

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -17,6 +17,8 @@ import {
   AtSign,
   Menu,
   X,
+  Building2,
+  Users,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -138,8 +140,16 @@ export function Header() {
                       <BookOpen className="mr-2 h-4 w-4" />
                       New repository
                     </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={() => navigate('/orgs/new')}>
+                      <Building2 className="mr-2 h-4 w-4" />
+                      New organization
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
+
+                {/* Organization Switcher */}
+                <OrganizationSwitcher />
 
                 {/* Notifications */}
                 <NotificationsDropdown />
@@ -264,16 +274,24 @@ export function Header() {
                     <CircleDot className="h-4 w-4" />
                     Issues
                   </Link>
-                  <Link
-                    to="/new"
-                    className="flex items-center gap-3 px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-lg transition-all"
-                    onClick={() => setMobileMenuOpen(false)}
-                  >
-                    <Plus className="h-4 w-4" />
-                    New repository
-                  </Link>
-                </>
-              )}
+                    <Link
+                      to="/new"
+                      className="flex items-center gap-3 px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-lg transition-all"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      <Plus className="h-4 w-4" />
+                      New repository
+                    </Link>
+                    <Link
+                      to="/orgs/new"
+                      className="flex items-center gap-3 px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-lg transition-all"
+                      onClick={() => setMobileMenuOpen(false)}
+                    >
+                      <Building2 className="h-4 w-4" />
+                      New organization
+                    </Link>
+                  </>
+                )}
               {!authenticated && (
                 <>
                   <Link
@@ -297,6 +315,59 @@ export function Header() {
         </div>
       )}
     </>
+  );
+}
+
+function OrganizationSwitcher() {
+  const navigate = useNavigate();
+  const { data: session } = useSession();
+  const { data: userOrgs } = trpc.organizations.listForUser.useQuery(undefined, {
+    enabled: !!session?.user,
+  });
+
+  if (!userOrgs || userOrgs.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm" className="hidden md:flex gap-1 h-9">
+          <Building2 className="h-4 w-4" />
+          <ChevronDown className="h-3 w-3" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Switch context</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => navigate(`/${session?.user?.username}`)}>
+          <User className="mr-2 h-4 w-4" />
+          <div className="flex flex-col">
+            <span className="font-medium">{session?.user?.name || session?.user?.username}</span>
+            <span className="text-xs text-muted-foreground">Personal account</span>
+          </div>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">Organizations</DropdownMenuLabel>
+        {userOrgs.map((membership) => (
+          <DropdownMenuItem
+            key={membership.orgId}
+            onClick={() => navigate(`/org/${membership.org.name}`)}
+          >
+            <Building2 className="mr-2 h-4 w-4" />
+            <div className="flex flex-col">
+              <span className="font-medium">{membership.org.displayName || membership.org.name}</span>
+              <span className="text-xs text-muted-foreground capitalize">{membership.role}</span>
+            </div>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => navigate('/orgs/new')}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create organization
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/apps/web/src/routes/new.tsx
+++ b/apps/web/src/routes/new.tsx
@@ -1,25 +1,68 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Code2, Lock, Globe } from 'lucide-react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Code2, Lock, Globe, Building2, User, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loading } from '@/components/ui/loading';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { trpc } from '@/lib/trpc';
 import { useSession } from '@/lib/auth-client';
 import { toastSuccess, toastError } from '@/components/ui/use-toast';
 
+type Owner = {
+  type: 'user' | 'organization';
+  id: string;
+  name: string;
+  displayName?: string;
+};
+
 export function NewRepoPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { data: session, isPending } = useSession();
   const user = session?.user;
+
+  // Fetch user's organizations for the owner selector
+  const { data: userOrgs } = trpc.organizations.listForUser.useQuery(undefined, {
+    enabled: !!user,
+  });
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  
+  // Owner selection - default to user, but can be an organization
+  const defaultOwner: Owner | null = user ? {
+    type: 'user',
+    id: user.id,
+    name: user.username || '',
+    displayName: user.name || user.username || '',
+  } : null;
+
+  // Check if we have an org query param to pre-select
+  const orgParam = searchParams.get('org');
+  const preselectedOrg = userOrgs?.find(m => m.org.name === orgParam);
+  
+  const [selectedOwner, setSelectedOwner] = useState<Owner | null>(null);
+  
+  // Set the owner once data is loaded
+  const currentOwner = selectedOwner || (preselectedOrg ? {
+    type: 'organization' as const,
+    id: preselectedOrg.org.id,
+    name: preselectedOrg.org.name,
+    displayName: preselectedOrg.org.displayName || preselectedOrg.org.name,
+  } : defaultOwner);
 
   const createRepo = trpc.repos.create.useMutation({
     onSuccess: (repo) => {
@@ -27,7 +70,28 @@ export function NewRepoPage() {
         title: 'Repository created',
         description: `${repo.name} has been created successfully.`,
       });
-      navigate(`/${user?.username}/${repo.name}`);
+      // Navigate to the correct owner path
+      const ownerPath = currentOwner?.type === 'organization' 
+        ? currentOwner.name 
+        : user?.username;
+      navigate(`/${ownerPath}/${repo.name}`);
+    },
+    onError: (err) => {
+      setError(err.message);
+      toastError({
+        title: 'Failed to create repository',
+        description: err.message,
+      });
+    },
+  });
+
+  const createOrgRepo = trpc.repos.createForOrg.useMutation({
+    onSuccess: (repo) => {
+      toastSuccess({
+        title: 'Repository created',
+        description: `${repo.name} has been created successfully.`,
+      });
+      navigate(`/${currentOwner?.name}/${repo.name}`);
     },
     onError: (err) => {
       setError(err.message);
@@ -68,12 +132,28 @@ export function NewRepoPage() {
       return;
     }
 
-    createRepo.mutate({
-      name: name.trim(),
-      description: description.trim() || undefined,
-      isPrivate,
-    });
+    if (!currentOwner) {
+      setError('Please select an owner');
+      return;
+    }
+
+    if (currentOwner.type === 'organization') {
+      createOrgRepo.mutate({
+        orgId: currentOwner.id,
+        name: name.trim(),
+        description: description.trim() || undefined,
+        isPrivate,
+      });
+    } else {
+      createRepo.mutate({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        isPrivate,
+      });
+    }
   };
+
+  const isMutating = createRepo.isPending || createOrgRepo.isPending;
 
   return (
     <div className="max-w-2xl mx-auto py-8">
@@ -97,7 +177,66 @@ export function NewRepoPage() {
             <div className="space-y-2">
               <Label htmlFor="name">Repository name *</Label>
               <div className="flex items-center gap-2">
-                <span className="text-muted-foreground">{user.username} /</span>
+                {/* Owner Selector */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" className="gap-2 min-w-[140px] justify-between">
+                      <div className="flex items-center gap-2">
+                        {currentOwner?.type === 'organization' ? (
+                          <Building2 className="h-4 w-4" />
+                        ) : (
+                          <User className="h-4 w-4" />
+                        )}
+                        <span className="truncate max-w-[100px]">
+                          {currentOwner?.displayName || currentOwner?.name || user?.username}
+                        </span>
+                      </div>
+                      <ChevronDown className="h-3 w-3 shrink-0" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="w-56">
+                    <DropdownMenuLabel>Select owner</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem 
+                      onClick={() => setSelectedOwner({
+                        type: 'user',
+                        id: user?.id || '',
+                        name: user?.username || '',
+                        displayName: user?.name || user?.username || '',
+                      })}
+                    >
+                      <User className="mr-2 h-4 w-4" />
+                      <div className="flex flex-col">
+                        <span className="font-medium">{user?.name || user?.username}</span>
+                        <span className="text-xs text-muted-foreground">Personal account</span>
+                      </div>
+                    </DropdownMenuItem>
+                    {userOrgs && userOrgs.length > 0 && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuLabel className="text-xs text-muted-foreground">Organizations</DropdownMenuLabel>
+                        {userOrgs.map((membership) => (
+                          <DropdownMenuItem 
+                            key={membership.orgId}
+                            onClick={() => setSelectedOwner({
+                              type: 'organization',
+                              id: membership.org.id,
+                              name: membership.org.name,
+                              displayName: membership.org.displayName || membership.org.name,
+                            })}
+                          >
+                            <Building2 className="mr-2 h-4 w-4" />
+                            <div className="flex flex-col">
+                              <span className="font-medium">{membership.org.displayName || membership.org.name}</span>
+                              <span className="text-xs text-muted-foreground capitalize">{membership.role}</span>
+                            </div>
+                          </DropdownMenuItem>
+                        ))}
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <span className="text-muted-foreground">/</span>
                 <Input
                   id="name"
                   placeholder="my-awesome-project"
@@ -184,8 +323,8 @@ export function NewRepoPage() {
               >
                 Cancel
               </Button>
-              <Button type="submit" disabled={createRepo.isPending}>
-                {createRepo.isPending ? 'Creating...' : 'Create repository'}
+              <Button type="submit" disabled={isMutating}>
+                {isMutating ? 'Creating...' : 'Create repository'}
               </Button>
             </div>
           </CardContent>

--- a/apps/web/src/routes/org/team-detail.tsx
+++ b/apps/web/src/routes/org/team-detail.tsx
@@ -1,0 +1,414 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Users, Plus, Trash2, Loader2, ChevronLeft, Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Loading } from '@/components/ui/loading';
+import { EmptyState } from '@/components/ui/empty-state';
+import { useSession } from '@/lib/auth-client';
+import { trpc } from '@/lib/trpc';
+
+export function TeamDetailPage() {
+  const { slug, teamId } = useParams<{ slug: string; teamId: string }>();
+  const { data: session } = useSession();
+  const authenticated = !!session?.user;
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const utils = trpc.useUtils();
+
+  const { data: org, isLoading: orgLoading } = trpc.organizations.get.useQuery(
+    { name: slug! },
+    { enabled: !!slug }
+  );
+
+  const { data: team, isLoading: teamLoading } = trpc.organizations.getTeam.useQuery(
+    { teamId: teamId! },
+    { enabled: !!teamId }
+  );
+
+  const { data: teamMembers, isLoading: membersLoading } = trpc.organizations.listTeamMembers.useQuery(
+    { teamId: teamId! },
+    { enabled: !!teamId }
+  );
+
+  const { data: orgMembers } = trpc.organizations.listMembers.useQuery(
+    { orgId: org?.id! },
+    { enabled: !!org?.id }
+  );
+
+  const { data: membership } = trpc.organizations.checkMembership.useQuery(
+    { orgId: org?.id!, userId: session?.user?.id! },
+    { enabled: !!org?.id && !!session?.user?.id }
+  );
+
+  // Search users (only among org members who aren't already in the team)
+  const { data: searchResults } = trpc.users.search.useQuery(
+    { query: searchQuery, limit: 10 },
+    { enabled: searchQuery.length >= 2 }
+  );
+
+  // Filter search results to only show org members who aren't in the team
+  const filteredResults = searchResults?.filter(user => {
+    const isOrgMember = orgMembers?.some(m => m.userId === user.id);
+    const isTeamMember = teamMembers?.some(m => m.userId === user.id);
+    return isOrgMember && !isTeamMember;
+  }) || [];
+
+  const addTeamMember = trpc.organizations.addTeamMember.useMutation({
+    onSuccess: () => {
+      setIsDialogOpen(false);
+      setSelectedUserId(null);
+      setSearchQuery('');
+      setError(null);
+      utils.organizations.listTeamMembers.invalidate({ teamId: teamId! });
+    },
+    onError: (err) => {
+      setError(err.message);
+    },
+  });
+
+  const removeTeamMember = trpc.organizations.removeTeamMember.useMutation({
+    onSuccess: () => {
+      utils.organizations.listTeamMembers.invalidate({ teamId: teamId! });
+    },
+  });
+
+  const handleAddMember = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!selectedUserId) {
+      setError('Please select a member to add');
+      return;
+    }
+
+    if (!teamId) return;
+
+    addTeamMember.mutate({
+      teamId,
+      userId: selectedUserId,
+    });
+  };
+
+  const handleRemove = (userId: string, username: string) => {
+    if (!teamId) return;
+    if (confirm(`Remove ${username} from the team?`)) {
+      removeTeamMember.mutate({ teamId, userId });
+    }
+  };
+
+  if (!authenticated) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Please sign in to access this page.</p>
+      </div>
+    );
+  }
+
+  const isLoading = orgLoading || teamLoading || membersLoading;
+
+  if (isLoading) {
+    return <Loading text="Loading team..." />;
+  }
+
+  if (!org) {
+    return (
+      <div className="text-center py-12">
+        <h2 className="text-2xl font-bold mb-2">Organization not found</h2>
+        <p className="text-muted-foreground">
+          The organization "{slug}" could not be found.
+        </p>
+      </div>
+    );
+  }
+
+  if (!team) {
+    return (
+      <div className="text-center py-12">
+        <h2 className="text-2xl font-bold mb-2">Team not found</h2>
+        <p className="text-muted-foreground">
+          The team could not be found.
+        </p>
+      </div>
+    );
+  }
+
+  const isOwner = membership?.role === 'owner';
+  const isAdmin = membership?.role === 'admin' || isOwner;
+
+  // Get selected user for display
+  const selectedUser = searchResults?.find(u => u.id === selectedUserId) ||
+    orgMembers?.find(m => m.userId === selectedUserId)?.user;
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 text-sm">
+        <Link
+          to={`/org/${slug}/teams`}
+          className="text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Teams
+        </Link>
+        <span className="text-muted-foreground">/</span>
+        <span>{team.name}</span>
+      </div>
+
+      <div>
+        <h1 className="text-3xl font-bold">{team.name}</h1>
+        {team.description && (
+          <p className="text-muted-foreground mt-1">{team.description}</p>
+        )}
+      </div>
+
+      {/* Team Members */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>Team Members</CardTitle>
+            <CardDescription>
+              {teamMembers?.length || 0} members in this team
+            </CardDescription>
+          </div>
+          {isAdmin && (
+            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm" className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add Member
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <form onSubmit={handleAddMember}>
+                  <DialogHeader>
+                    <DialogTitle>Add Team Member</DialogTitle>
+                    <DialogDescription>
+                      Add an organization member to this team. Only organization members can be added to teams.
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4 py-4">
+                    <div className="space-y-2">
+                      <Label>Select member</Label>
+                      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+                        <PopoverTrigger asChild>
+                          <Button
+                            variant="outline"
+                            role="combobox"
+                            aria-expanded={popoverOpen}
+                            className="w-full justify-between"
+                          >
+                            {selectedUser ? (
+                              <div className="flex items-center gap-2">
+                                <Avatar className="h-5 w-5">
+                                  <AvatarImage src={selectedUser.avatarUrl || undefined} />
+                                  <AvatarFallback className="text-xs">
+                                    {(selectedUser.username || 'U').slice(0, 2).toUpperCase()}
+                                  </AvatarFallback>
+                                </Avatar>
+                                <span>{selectedUser.name || selectedUser.username}</span>
+                              </div>
+                            ) : (
+                              <span className="text-muted-foreground">Search for a member...</span>
+                            )}
+                            <Search className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                          </Button>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-full p-0" align="start">
+                          <Command>
+                            <CommandInput
+                              placeholder="Search members..."
+                              value={searchQuery}
+                              onValueChange={setSearchQuery}
+                            />
+                            <CommandList>
+                              <CommandEmpty>
+                                {searchQuery.length < 2 
+                                  ? 'Type to search...' 
+                                  : 'No members found.'}
+                              </CommandEmpty>
+                              <CommandGroup>
+                                {filteredResults.map((user) => (
+                                  <CommandItem
+                                    key={user.id}
+                                    value={user.username || user.id}
+                                    onSelect={() => {
+                                      setSelectedUserId(user.id);
+                                      setPopoverOpen(false);
+                                    }}
+                                  >
+                                    <div className="flex items-center gap-2">
+                                      <Avatar className="h-6 w-6">
+                                        <AvatarImage src={user.avatarUrl || undefined} />
+                                        <AvatarFallback className="text-xs">
+                                          {(user.username || 'U').slice(0, 2).toUpperCase()}
+                                        </AvatarFallback>
+                                      </Avatar>
+                                      <div className="flex flex-col">
+                                        <span className="font-medium">{user.name || user.username}</span>
+                                        <span className="text-xs text-muted-foreground">@{user.username}</span>
+                                      </div>
+                                    </div>
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            </CommandList>
+                          </Command>
+                        </PopoverContent>
+                      </Popover>
+                      <p className="text-xs text-muted-foreground">
+                        Search for organization members by name or username.
+                      </p>
+                    </div>
+
+                    {error && (
+                      <div className="p-3 rounded-md bg-destructive/10 text-destructive text-sm">
+                        {error}
+                      </div>
+                    )}
+                  </div>
+                  <DialogFooter>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setIsDialogOpen(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button type="submit" disabled={addTeamMember.isPending || !selectedUserId}>
+                      {addTeamMember.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                      Add Member
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
+          )}
+        </CardHeader>
+        <CardContent>
+          {!teamMembers || teamMembers.length === 0 ? (
+            <EmptyState
+              icon={Users}
+              title="No team members"
+              description="Add organization members to this team."
+            />
+          ) : (
+            <div className="divide-y">
+              {teamMembers.map((member) => (
+                <TeamMemberRow
+                  key={member.userId}
+                  member={member}
+                  currentUserId={session?.user?.id || ''}
+                  isAdmin={isAdmin}
+                  onRemove={() => handleRemove(member.userId, member.user?.username || 'this user')}
+                  isRemoving={removeTeamMember.isPending}
+                />
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface TeamMemberRowProps {
+  member: {
+    userId: string;
+    joinedAt: Date | string;
+    user?: {
+      id?: string;
+      username?: string | null;
+      name?: string | null;
+      avatarUrl?: string | null;
+    } | null;
+  };
+  currentUserId: string;
+  isAdmin: boolean;
+  onRemove: () => void;
+  isRemoving: boolean;
+}
+
+function TeamMemberRow({
+  member,
+  currentUserId,
+  isAdmin,
+  onRemove,
+  isRemoving,
+}: TeamMemberRowProps) {
+  const isSelf = member.userId === currentUserId;
+  const canRemove = isAdmin || isSelf;
+
+  return (
+    <div className="flex items-center justify-between py-4 first:pt-0 last:pb-0">
+      <div className="flex items-center gap-3">
+        <Avatar>
+          <AvatarImage src={member.user?.avatarUrl || undefined} />
+          <AvatarFallback>
+            {(member.user?.username || 'U').slice(0, 2).toUpperCase()}
+          </AvatarFallback>
+        </Avatar>
+        <div>
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/${member.user?.username}`}
+              className="font-medium hover:text-primary"
+            >
+              {member.user?.name || member.user?.username}
+            </Link>
+            {isSelf && (
+              <span className="text-xs text-muted-foreground">(you)</span>
+            )}
+          </div>
+          <div className="text-sm text-muted-foreground">
+            @{member.user?.username}
+          </div>
+        </div>
+      </div>
+      {canRemove && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onRemove}
+          disabled={isRemoving}
+          className="text-destructive hover:text-destructive hover:bg-destructive/10"
+        >
+          {isRemoving ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Trash2 className="h-4 w-4" />
+          )}
+        </Button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive organization support to the web application:

- **Organization context switcher** in the header for quick navigation between personal account and organizations
- **Create repositories for organizations** - users can now select an organization as the owner when creating new repos
- **Team detail page** at `/org/:slug/teams/:teamId` with full member management (add/remove members)
- **Improved member invitation UX** - replaced UUID input with searchable user picker

## Changes

### Header (`apps/web/src/components/layout/header.tsx`)
- Added `OrganizationSwitcher` component showing user's organizations
- Added "New organization" option to the create menu

### New Repository Page (`apps/web/src/routes/new.tsx`)
- Added owner selector dropdown to choose between personal account and organizations
- Supports `?org=slug` query param to pre-select an organization

### Team Detail Page (`apps/web/src/routes/org/team-detail.tsx`)
- New page for viewing and managing team members
- Search-based member adding (filters to org members not already in team)
- Remove member functionality

### Members Page (`apps/web/src/routes/org/members.tsx`)
- Replaced User ID input with searchable user picker
- Shows user avatars and details in search results
- Filters out existing members from search

### Backend (`src/api/trpc/routers/repos.ts`)
- Added `createForOrg` mutation for creating organization repositories