### PR TITLE
docs: simplify architecture overview

### DIFF
--- a/docs/api-reference/notifications.mdx
+++ b/docs/api-reference/notifications.mdx
@@ -3,8 +3,6 @@ title: "Notifications API"
 description: "API reference for notification management"
 ---
 
-# Notifications API
-
 The Notifications API allows you to manage user notifications for repository events.
 
 ## Overview

--- a/docs/api-reference/objects.mdx
+++ b/docs/api-reference/objects.mdx
@@ -3,8 +3,6 @@ title: "Git Objects"
 description: "Working with blobs, trees, commits, and tags programmatically"
 ---
 
-# Git Objects
-
 wit provides classes for working with Git objects directly. This is useful for building tools, analyzing repositories, or understanding Git internals.
 
 ## Object Types

--- a/docs/api-reference/organizations.mdx
+++ b/docs/api-reference/organizations.mdx
@@ -3,8 +3,6 @@ title: "Organizations API"
 description: "API reference for organization and team management"
 ---
 
-# Organizations API
-
 The Organizations API provides endpoints for managing organizations, members, and teams.
 
 ## Overview

--- a/docs/api-reference/overview.mdx
+++ b/docs/api-reference/overview.mdx
@@ -3,8 +3,6 @@ title: API Reference Overview
 description: "Use wit programmatically in your Node.js projects"
 ---
 
-# API Reference
-
 wit can be used as a library in your Node.js applications, giving you programmatic access to all version control operations.
 
 ## Installation

--- a/docs/api-reference/repository.mdx
+++ b/docs/api-reference/repository.mdx
@@ -3,8 +3,6 @@ title: Repository
 description: "Repository class API reference"
 ---
 
-# Repository
-
 The `Repository` class is the main entry point for all repository operations.
 
 ## Import

--- a/docs/api-reference/search.mdx
+++ b/docs/api-reference/search.mdx
@@ -3,8 +3,6 @@ title: SearchEngine
 description: "SearchEngine class API reference"
 ---
 
-# SearchEngine
-
 The `SearchEngine` class provides powerful search capabilities across your repository.
 
 ## Import

--- a/docs/api-reference/webhooks.mdx
+++ b/docs/api-reference/webhooks.mdx
@@ -3,8 +3,6 @@ title: "Webhooks API"
 description: "API reference for webhook management"
 ---
 
-# Webhooks API
-
 The Webhooks API allows you to create and manage webhooks that receive HTTP callbacks when events occur in your repositories.
 
 ## Overview

--- a/docs/architecture/overview.mdx
+++ b/docs/architecture/overview.mdx
@@ -3,492 +3,62 @@ title: "Architecture Overview"
 description: "How wit works under the hood"
 ---
 
-# Architecture Overview
+wit is a Git-compatible version control system written in TypeScript, with an integrated hosting platform.
 
-wit is a complete Git implementation written in TypeScript. This document explains the internal architecture for contributors and anyone curious about how version control works.
-
-## High-Level Architecture
-
-### CLI Architecture
+## System Overview
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                          CLI Layer                           │
-│  src/cli.ts → src/commands/*.ts                              │
-├─────────────────────────────────────────────────────────────┤
-│                        Core Layer                            │
-│  Repository │ ObjectStore │ Index │ Refs │ Merge │ Diff     │
-├─────────────────────────────────────────────────────────────┤
-│                      Protocol Layer                          │
-│  SmartHTTP │ PackfileReader │ PackfileWriter │ Pack          │
-├─────────────────────────────────────────────────────────────┤
-│                      Storage Layer                           │
-│  Filesystem (objects/, refs/, index, HEAD)                   │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                           CLI                                │
+│                      src/commands/*                          │
+├────────────────────────┬─────────────────────────────────────┤
+│      Core Git          │           Platform                  │
+│  - Repository          │  - API Server (Hono + tRPC)         │
+│  - Objects & Refs      │  - Web App (React)                  │
+│  - Merge & Diff        │  - Database (PostgreSQL)            │
+│  - Smart HTTP Protocol │  - Git hosting                      │
+├────────────────────────┴─────────────────────────────────────┤
+│                        Storage                               │
+│           .wit/objects    .wit/refs    PostgreSQL            │
+└──────────────────────────────────────────────────────────────┘
 ```
 
-### Platform Architecture
+## Key Components
 
-wit also includes a full platform for hosting repositories:
+| Directory | Purpose |
+|-----------|---------|
+| `src/commands/` | CLI command handlers |
+| `src/core/` | Git internals: objects, refs, index, merge, diff |
+| `src/core/protocol/` | Smart HTTP, packfile read/write |
+| `src/server/` | Hono server, Git HTTP endpoints |
+| `src/api/trpc/` | tRPC routers for the platform API |
+| `src/db/` | Drizzle schema and data models |
+| `src/ai/` | AI agent and tools |
+| `src/ui/` | Terminal UI, web UI, graph rendering |
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         wit Platform                             │
-├─────────────────────────────────────────────────────────────────┤
-│  Web App (React)          │  API Server (Hono)                  │
-│  - Repository browser     │  - tRPC API                         │
-│  - Pull requests UI       │  - Git Smart HTTP                   │
-│  - Issues UI              │  - Health checks                    │
-├───────────────────────────┼─────────────────────────────────────┤
-│  CLI (wit)                │  Primitives                         │
-│  - Local git ops          │  - Filesystem (versioned files)     │
-│  - wit pr, wit issue      │  - Knowledge (key-value store)      │
-│  - wit serve              │  - Git-backed storage               │
-├───────────────────────────┴─────────────────────────────────────┤
-│                         Storage Layer                            │
-│  - Git Objects (filesystem)  - PostgreSQL (Drizzle ORM)         │
-└─────────────────────────────────────────────────────────────────┘
-```
+## How Git Storage Works
 
-### Database Schema
+wit stores data the same way Git does:
 
-The platform uses PostgreSQL for user data, PRs, and issues:
+- **Objects** (blobs, trees, commits, tags) are content-addressed by SHA-1 hash
+- **Refs** (branches, tags) are files containing commit hashes
+- **Index** tracks staged files for the next commit
+- **Packfiles** bundle objects for network transfer
 
-| Table | Description |
-|-------|-------------|
-| `users` | User accounts and OAuth |
-| `organizations` | Teams and organizations |
-| `repositories` | Repository metadata |
-| `pull_requests` | Pull request data |
-| `issues` | Issue tracking |
-| `activities` | Activity feed |
-| `webhooks` | Webhook configurations |
+All objects live in `.wit/objects/`, refs in `.wit/refs/`.
 
-### tRPC API Routers
+## Network Protocol
 
-The API is organized into routers:
+wit implements Git Smart HTTP for clone/fetch/push:
 
-| Router | Purpose |
-|--------|---------|
-| `auth` | Login, logout, register |
-| `users` | User profiles |
-| `repos` | Repository CRUD, stars, search |
-| `pulls` | Pull request operations |
-| `issues` | Issue management |
-| `comments` | PR and issue comments |
-| `activity` | Activity feeds |
+1. Client discovers refs via `GET /info/refs`
+2. Client/server exchange packfiles via `POST /git-upload-pack` or `/git-receive-pack`
 
-## Directory Structure
+## Platform
 
-```
-src/
-├── cli.ts                 # CLI entry point, command routing
-├── commands/              # Command implementations
-│   ├── add.ts             # wit add
-│   ├── commit.ts          # wit commit
-│   ├── push.ts            # wit push
-│   ├── pr.ts              # wit pr (pull requests)
-│   ├── issue.ts           # wit issue
-│   ├── serve.ts           # wit serve
-│   └── ...
-├── core/                  # Core Git functionality
-│   ├── repository.ts      # Repository class
-│   ├── object-store.ts    # Object read/write
-│   ├── object.ts          # Blob, Tree, Commit, Tag classes
-│   ├── index.ts           # Staging area
-│   ├── refs.ts            # Reference management
-│   ├── merge.ts           # Merge algorithms
-│   ├── diff.ts            # Diff generation
-│   ├── github.ts          # GitHub OAuth
-│   └── protocol/          # Git protocol
-│       ├── smart-http.ts  # Smart HTTP client
-│       ├── pack.ts        # Pack utilities
-│       └── packfile-*.ts  # Packfile read/write
-├── server/                # Git server
-│   ├── index.ts           # Hono server
-│   ├── routes/
-│   │   └── git.ts         # Smart HTTP endpoints
-│   ├── middleware/
-│   │   └── auth.ts        # Authentication
-│   └── storage/
-│       ├── repos.ts       # Repository management
-│       └── sync.ts        # Database sync
-├── db/                    # Database layer
-│   ├── schema.ts          # Drizzle schema
-│   ├── models/            # Data access
-│   │   ├── user.ts
-│   │   ├── repository.ts
-│   │   ├── pull-request.ts
-│   │   └── issue.ts
-│   └── seed.ts            # Development data
-├── api/                   # API layer
-│   ├── client.ts          # API client
-│   └── trpc/              # tRPC setup
-│       ├── index.ts
-│       ├── trpc.ts
-│       ├── context.ts
-│       └── routers/
-│           ├── auth.ts
-│           ├── repos.ts
-│           ├── pulls.ts
-│           └── issues.ts
-├── primitives/            # Git-backed primitives
-│   ├── filesystem.ts      # Versioned file operations
-│   ├── knowledge.ts       # Key-value store
-│   └── types.ts           # Type definitions
-├── ai/                    # AI integration
-│   ├── agent.ts           # Mastra agent
-│   ├── mastra.ts          # Configuration
-│   └── tools/             # Agent tools
-├── ui/                    # Visual interfaces
-│   ├── web-premium.ts     # Web UI
-│   ├── tui.ts             # Terminal UI
-│   └── graph.ts           # Commit graph
-└── utils/                 # Utilities
-    ├── fs.ts              # Filesystem helpers
-    ├── hash.ts            # SHA-1/SHA-256
-    └── compression.ts     # Zlib
-```
+The hosting platform adds:
 
-## Core Concepts
-
-### Git Objects
-
-All data in Git is stored as objects. There are four types:
-
-| Type | Description | Content |
-|------|-------------|---------|
-| **blob** | File content | Raw bytes |
-| **tree** | Directory | List of (mode, name, hash) entries |
-| **commit** | Snapshot | Tree hash, parent(s), author, message |
-| **tag** | Named pointer | Object hash, tagger, message |
-
-Each object is:
-1. Serialized to bytes
-2. Prefixed with `{type} {size}\0`
-3. Hashed with SHA-1 (or SHA-256)
-4. Compressed with zlib
-5. Stored at `.wit/objects/{hash[0:2]}/{hash[2:]}`
-
-```typescript
-// src/core/object.ts
-export class Blob extends GitObject {
-  serialize(): Buffer {
-    return this.content;
-  }
-}
-
-export class Tree extends GitObject {
-  serialize(): Buffer {
-    // Sort entries, then format as:
-    // {mode} {name}\0{20-byte-hash}
-  }
-}
-
-export class Commit extends GitObject {
-  serialize(): Buffer {
-    // tree {hash}\n
-    // parent {hash}\n (0 or more)
-    // author {name} <{email}> {timestamp} {tz}\n
-    // committer {name} <{email}> {timestamp} {tz}\n
-    // \n
-    // {message}
-  }
-}
-```
-
-### Object Store
-
-The `ObjectStore` class handles reading and writing objects:
-
-```typescript
-// src/core/object-store.ts
-export class ObjectStore {
-  // Write object, return hash
-  writeObject(obj: GitObject): string {
-    const content = obj.serialize();
-    const hash = hashObject(obj.type, content);
-    const buffer = createObjectBuffer(obj.type, content);
-    const compressed = compress(buffer);
-    writeFile(this.getPath(hash), compressed);
-    return hash;
-  }
-
-  // Read object by hash
-  readObject(hash: string): GitObject {
-    const compressed = readFile(this.getPath(hash));
-    const buffer = decompress(compressed);
-    const { type, content } = parseObjectBuffer(buffer);
-    return deserialize(type, content);
-  }
-}
-```
-
-### Index (Staging Area)
-
-The index tracks files staged for the next commit:
-
-```typescript
-// src/core/index.ts
-interface IndexEntry {
-  mode: string;      // File mode (100644, 100755, etc.)
-  hash: string;      // Blob hash
-  stage: number;     // 0=normal, 1/2/3=conflict
-  path: string;      // File path
-  // Metadata for change detection:
-  ctime: number;
-  mtime: number;
-  size: number;
-}
-```
-
-The index is stored at `.wit/index` as JSON (Git uses binary format).
-
-### References
-
-References are pointers to commits:
-
-```
-.wit/
-├── HEAD                    # Current branch (symbolic ref)
-├── refs/
-│   ├── heads/
-│   │   ├── main            # Branch: contains commit hash
-│   │   └── feature
-│   ├── tags/
-│   │   └── v1.0.0          # Tag: contains commit/tag hash
-│   └── remotes/
-│       └── origin/
-│           └── main        # Remote tracking branch
-```
-
-```typescript
-// src/core/refs.ts
-export class RefManager {
-  resolve(ref: string): string | null {
-    // HEAD → refs/heads/main → {commit-hash}
-  }
-  
-  update(ref: string, hash: string): void {
-    // Write hash to ref file
-  }
-}
-```
-
-### Repository
-
-The `Repository` class ties everything together:
-
-```typescript
-// src/core/repository.ts
-export class Repository {
-  readonly gitDir: string;      // .wit directory
-  readonly workDir: string;     // Working directory
-  readonly objects: ObjectStore;
-  readonly index: Index;
-  readonly refs: RefManager;
-  
-  // High-level operations
-  add(paths: string[]): void;
-  commit(message: string): string;
-  checkout(ref: string): void;
-  merge(branch: string): MergeResult;
-}
-```
-
-## Git Protocol
-
-### Smart HTTP
-
-wit implements Git's Smart HTTP protocol for clone/fetch/push:
-
-```
-Clone/Fetch:
-1. GET /info/refs?service=git-upload-pack
-   ← Server sends refs with capabilities
-2. POST /git-upload-pack
-   → Client sends wanted refs
-   ← Server sends packfile
-
-Push:
-1. GET /info/refs?service=git-receive-pack
-   ← Server sends refs with capabilities
-2. POST /git-receive-pack
-   → Client sends ref updates + packfile
-   ← Server sends status
-```
-
-```typescript
-// src/core/protocol/smart-http.ts
-export class SmartHttpClient {
-  async discoverRefs(): Promise<RefInfo[]>;
-  async fetchPack(wants: string[]): Promise<Buffer>;
-  async pushPack(updates: RefUpdate[], pack: Buffer): Promise<PushResult>;
-}
-```
-
-### Packfiles
-
-Packfiles are compressed archives of objects, used for network transfer:
-
-```
-PACK header (12 bytes):
-  - "PACK" signature (4 bytes)
-  - Version (4 bytes, big-endian)
-  - Object count (4 bytes, big-endian)
-
-Objects (variable):
-  - Type + size (varint encoded)
-  - Compressed data (zlib)
-
-Checksum (20 bytes):
-  - SHA-1 of everything before
-```
-
-```typescript
-// src/core/protocol/packfile-writer.ts
-export function createPackfile(objects: PackableObject[]): Buffer {
-  // Write header
-  // For each object: write type, size, compressed data
-  // Write checksum
-}
-
-// src/core/protocol/packfile-reader.ts
-export function readPackfile(data: Buffer): GitObject[] {
-  // Parse header
-  // Read each object
-  // Verify checksum
-}
-```
-
-## Algorithms
-
-### Three-Way Merge
-
-When merging branches, wit uses three-way merge:
-
-```
-      A (base)
-     / \
-    B   C
-     \ /
-      M (merged)
-```
-
-For each file:
-1. If B and C are same → use either
-2. If only B changed → use B
-3. If only C changed → use C
-4. If both changed differently → conflict
-
-```typescript
-// src/core/merge.ts
-export function threeWayMerge(
-  base: string,
-  ours: string,
-  theirs: string
-): MergeResult {
-  // Line-by-line comparison
-  // Detect conflicts
-  // Generate merged content or conflict markers
-}
-```
-
-### Diff Algorithm
-
-wit uses Myers' diff algorithm to compute changes:
-
-```typescript
-// src/core/diff.ts
-export function diff(a: string[], b: string[]): DiffHunk[] {
-  // Find shortest edit script
-  // Group into hunks
-  // Return add/remove operations
-}
-```
-
-## Data Flow Examples
-
-### `wit add file.txt`
-
-```
-1. Read file.txt content
-2. Create Blob object
-3. Write blob to object store → get hash
-4. Update index with (path, hash, mode)
-5. Save index to .wit/index
-```
-
-### `wit commit -m "message"`
-
-```
-1. Read index entries
-2. Build tree structure from entries
-3. Create Tree objects (bottom-up)
-4. Get parent commit hash from HEAD
-5. Create Commit object (tree, parent, message)
-6. Write commit to object store → get hash
-7. Update refs/heads/{branch} with hash
-8. Record in journal (for undo)
-```
-
-### `wit push origin main`
-
-```
-1. Discover remote refs (GET /info/refs)
-2. Find local commit hash
-3. Find remote commit hash
-4. Collect objects to send (local - remote)
-5. Create packfile from objects
-6. Send ref update + packfile (POST /git-receive-pack)
-7. Parse response for success/failure
-```
-
-## Extension Points
-
-### Adding a New Command
-
-1. Create `src/commands/mycommand.ts`:
-
-```typescript
-export function handleMyCommand(args: string[]): void {
-  const repo = Repository.open('.');
-  // Your logic here
-}
-```
-
-2. Add to `src/cli.ts`:
-
-```typescript
-case 'mycommand':
-  handleMyCommand(args.slice(1));
-  break;
-```
-
-### Adding a New Object Type
-
-1. Extend `GitObject` in `src/core/object.ts`
-2. Implement `serialize()` and `static deserialize()`
-3. Add to type registry in `ObjectStore`
-
-### Adding Protocol Support
-
-1. Implement in `src/core/protocol/`
-2. Follow existing patterns in `smart-http.ts`
-3. Add authentication in `getCredentials()`
-
-## Testing
-
-```bash
-# Run all tests
-npm test
-
-# Run specific test file
-npm test -- src/core/__tests__/repository.test.ts
-
-# Run with coverage
-npm run test:coverage
-```
-
-Test files are located alongside source files in `__tests__/` directories.
+- **PostgreSQL** for users, orgs, repos, PRs, issues
+- **tRPC API** for the web app and CLI commands like `wit pr`
+- **React web app** for browsing repos and managing PRs
 

--- a/docs/commands/advanced.mdx
+++ b/docs/commands/advanced.mdx
@@ -3,8 +3,6 @@ title: Advanced Commands
 description: "Power user commands for advanced workflows"
 ---
 
-# Advanced Commands
-
 These commands provide powerful capabilities for advanced workflows.
 
 <Note>

--- a/docs/commands/basic-workflow.mdx
+++ b/docs/commands/basic-workflow.mdx
@@ -3,8 +3,6 @@ title: Basic Workflow
 description: "Essential commands for daily version control"
 ---
 
-# Basic Workflow Commands
-
 These are the commands you'll use most often for day-to-day version control.
 
 ## init

--- a/docs/commands/branches.mdx
+++ b/docs/commands/branches.mdx
@@ -3,8 +3,6 @@ title: Branches
 description: "Create, switch, and manage branches"
 ---
 
-# Branch Commands
-
 wit provides intuitive branch management with automatic stashing when switching branches.
 
 ## branch

--- a/docs/commands/debugging.mdx
+++ b/docs/commands/debugging.mdx
@@ -3,8 +3,6 @@ title: Debugging
 description: Find bugs with bisect, view file history with show, and clean up with clean
 ---
 
-# Debugging Commands
-
 wit provides powerful tools for debugging issues in your codebase, understanding file history, and cleaning up your working directory.
 
 ## Bisect

--- a/docs/commands/history-rewriting.mdx
+++ b/docs/commands/history-rewriting.mdx
@@ -3,8 +3,6 @@ title: History Rewriting
 description: Modify commit history with reset, revert, cherry-pick, and rebase
 ---
 
-# History Rewriting
-
 wit provides powerful commands for modifying commit history. Use these carefully - some operations can permanently alter your repository's history.
 
 ## Overview

--- a/docs/commands/merge.mdx
+++ b/docs/commands/merge.mdx
@@ -3,8 +3,6 @@ title: Merge
 description: "Merge branches and resolve conflicts"
 ---
 
-# Merge Commands
-
 wit provides an improved merge experience with structured conflict resolution.
 
 ## merge

--- a/docs/commands/overview.mdx
+++ b/docs/commands/overview.mdx
@@ -3,8 +3,6 @@ title: Commands
 description: "All wit commands organized by category"
 ---
 
-# Commands
-
 wit commands are organized by what you're trying to do.
 
 <CardGroup cols={2}>

--- a/docs/commands/quality-of-life.mdx
+++ b/docs/commands/quality-of-life.mdx
@@ -3,8 +3,6 @@ title: Quality of Life
 description: "Productivity commands that make version control enjoyable"
 ---
 
-# Quality of Life Commands
-
 These commands are designed to make common tasks faster and more enjoyable.
 
 ## wip

--- a/docs/commands/remotes.mdx
+++ b/docs/commands/remotes.mdx
@@ -3,8 +3,6 @@ title: "Remote Operations"
 description: "Clone, fetch, pull, and push to remote repositories"
 ---
 
-# Remote Operations
-
 wit provides full support for remote Git operations, allowing you to collaborate with others using any Git hosting service including GitHub, GitLab, Bitbucket, or self-hosted servers.
 
 ## Quick Reference

--- a/docs/commands/stash.mdx
+++ b/docs/commands/stash.mdx
@@ -3,8 +3,6 @@ title: Stash
 description: Temporarily save changes without committing
 ---
 
-# Stash
-
 The stash command saves your uncommitted changes temporarily, allowing you to switch contexts and come back to your work later. Unlike Git's cryptic stash, wit provides clear, intuitive stash management.
 
 ## Quick Reference

--- a/docs/commands/tags.mdx
+++ b/docs/commands/tags.mdx
@@ -3,8 +3,6 @@ title: Tags
 description: Create, list, and manage tags for releases and milestones
 ---
 
-# Tags
-
 Tags mark specific points in your repository's history, typically used for releases and milestones. wit supports both lightweight and annotated tags.
 
 ## Quick Reference

--- a/docs/commands/undo-history.mdx
+++ b/docs/commands/undo-history.mdx
@@ -3,8 +3,6 @@ title: Undo & History
 description: "Powerful undo capabilities for any operation"
 ---
 
-# Undo & History Commands
-
 wit provides the most powerful undo capabilities of any version control system. Made a mistake? Just undo it.
 
 ## undo

--- a/docs/configuration/directory-structure.mdx
+++ b/docs/configuration/directory-structure.mdx
@@ -3,8 +3,6 @@ title: Directory Structure
 description: "Understanding the .wit directory"
 ---
 
-# Directory Structure
-
 The `.wit` directory contains all repository data and metadata.
 
 ## Overview

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -3,8 +3,6 @@ title: "Environment Variables"
 description: "Complete reference for wit environment variables"
 ---
 
-# Environment Variables
-
 This page documents all environment variables used by wit for configuration.
 
 ## AI Features

--- a/docs/configuration/overview.mdx
+++ b/docs/configuration/overview.mdx
@@ -3,8 +3,6 @@ title: Configuration Overview
 description: "Configure wit to match your workflow"
 ---
 
-# Configuration
-
 wit stores configuration in `.wit/config` using an INI-like format, similar to Git.
 
 ## Configuration Levels

--- a/docs/configuration/repository.mdx
+++ b/docs/configuration/repository.mdx
@@ -3,8 +3,6 @@ title: Repository Configuration
 description: "Configure individual repository settings"
 ---
 
-# Repository Configuration
-
 Each repository has its own configuration in `.wit/config`.
 
 ## Core Settings

--- a/docs/configuration/shell-integration.mdx
+++ b/docs/configuration/shell-integration.mdx
@@ -3,8 +3,6 @@ title: Shell Integration
 description: "Display the current wit branch in your terminal prompt"
 ---
 
-# Shell Integration
-
 Display your current wit branch directly in your terminal prompt, just like you would with Git. This helps you always know which branch you're working on.
 
 ## How It Works

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -3,8 +3,6 @@ title: "Contributing"
 description: "How to contribute to wit"
 ---
 
-# Contributing to wit
-
 Thank you for your interest in contributing to wit! This guide will help you get started.
 
 ## Getting Started

--- a/docs/features/ai-powered.mdx
+++ b/docs/features/ai-powered.mdx
@@ -3,8 +3,6 @@ title: AI-Powered Features
 description: "AI-generated commit messages, code review, and intelligent assistance"
 ---
 
-# AI-Powered Features
-
 You made changes. The AI can see exactly what changed. Why are you still writing commit messages?
 
 ```bash

--- a/docs/features/ci-cd.mdx
+++ b/docs/features/ci-cd.mdx
@@ -3,8 +3,6 @@ title: CI/CD Engine
 description: Built-in GitHub Actions-compatible CI/CD workflows
 ---
 
-# CI/CD Engine
-
 wit includes a built-in CI/CD engine that can parse and validate GitHub Actions-compatible workflow files. Define your workflows in `.wit/workflows/` and wit understands them natively.
 
 <Note>

--- a/docs/features/collaborators.mdx
+++ b/docs/features/collaborators.mdx
@@ -3,8 +3,6 @@ title: "Collaborators"
 description: "Manage repository collaborators, teams, and permissions"
 ---
 
-# Collaborators
-
 wit provides a comprehensive system for managing repository access through collaborators, teams, and role-based permissions.
 
 ## Overview

--- a/docs/features/github.mdx
+++ b/docs/features/github.mdx
@@ -3,8 +3,6 @@ title: "GitHub Integration"
 description: "Seamless authentication and workflow with GitHub"
 ---
 
-# GitHub Integration
-
 wit provides first-class GitHub integration with OAuth authentication, making it easy to clone, push, and pull from GitHub repositories.
 
 ## Authentication

--- a/docs/features/hooks.mdx
+++ b/docs/features/hooks.mdx
@@ -3,8 +3,6 @@ title: Hooks
 description: "Pre-commit hooks without the npm package soup"
 ---
 
-# Hooks
-
 In a typical JS project, running a linter before commit requires:
 
 - husky

--- a/docs/features/large-files.mdx
+++ b/docs/features/large-files.mdx
@@ -3,8 +3,6 @@ title: Large File Support
 description: "Handle large files efficiently without external tools"
 ---
 
-# Large File Support
-
 Git LFS is a workaround for a problem wit doesn't have.
 
 ```bash

--- a/docs/features/monorepo-scopes.mdx
+++ b/docs/features/monorepo-scopes.mdx
@@ -3,8 +3,6 @@ title: Monorepo Scopes
 description: "Limit operations to specific paths in your repository"
 ---
 
-# Monorepo Scopes
-
 Scopes let you focus on specific parts of a large repository, making wit faster and less noisy.
 
 ## Overview

--- a/docs/features/review.mdx
+++ b/docs/features/review.mdx
@@ -3,8 +3,6 @@ title: Code Review
 description: "Pre-push AI code review powered by CodeRabbit"
 ---
 
-# Code Review
-
 wit includes a powerful code review command powered by [CodeRabbit](https://coderabbit.ai), our AI code review partner. Catch issues before you push.
 
 ## Overview

--- a/docs/features/search.mdx
+++ b/docs/features/search.mdx
@@ -3,8 +3,6 @@ title: Semantic Search
 description: "Ask questions about your codebase in natural language"
 ---
 
-# Semantic Search
-
 New codebase. Where's the authentication logic?
 
 ```bash

--- a/docs/features/smart-status.mdx
+++ b/docs/features/smart-status.mdx
@@ -3,8 +3,6 @@ title: "Smart Status"
 description: "The intelligent default command that understands your workflow"
 ---
 
-# Smart Status
-
 `git status` shows you what changed. `wit` shows you what matters.
 
 Run wit with no arguments:

--- a/docs/features/stacked-diffs.mdx
+++ b/docs/features/stacked-diffs.mdx
@@ -3,8 +3,6 @@ title: "Stacked Diffs"
 description: "Break down large features into smaller, dependent branches"
 ---
 
-# Stacked Diffs
-
 Your PR is 2,000 lines. Your reviewer's eyes glaze over. "LGTM" with no real review.
 
 Stacked diffs fix this. Break one big feature into a stack of small, reviewable PRs:

--- a/docs/features/submodules.mdx
+++ b/docs/features/submodules.mdx
@@ -3,8 +3,6 @@ title: Submodules
 description: "Manage nested repositories within your project"
 ---
 
-# Submodules
-
 Submodules let you include other repositories inside your project while keeping them separate.
 
 ## Overview

--- a/docs/features/tokens.mdx
+++ b/docs/features/tokens.mdx
@@ -3,8 +3,6 @@ title: Personal Access Tokens
 description: "Authenticate with the wit API using personal access tokens"
 ---
 
-# Personal Access Tokens
-
 Personal Access Tokens (PATs) provide a secure way to authenticate with the wit platform API from scripts, CI/CD pipelines, and other automated workflows.
 
 ## Overview

--- a/docs/features/worktrees.mdx
+++ b/docs/features/worktrees.mdx
@@ -3,8 +3,6 @@ title: Worktrees
 description: "Work on multiple branches simultaneously"
 ---
 
-# Worktrees
-
 Worktrees let you have multiple working directories for the same repository, each on a different branch.
 
 ## Overview

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,8 +3,6 @@ title: Introduction
 description: "A modern Git implementation in TypeScript with AI-powered features"
 ---
 
-# wit
-
 Git is powerful but hostile. Cryptic errors, no real undo, and `checkout` does five different things.
 
 **wit** is a Git-compatible CLI that fixes the UX problems while adding AI features and visual interfaces.

--- a/docs/platform/issues.mdx
+++ b/docs/platform/issues.mdx
@@ -3,8 +3,6 @@ title: "Issues"
 description: "Track issues and bugs from the command line"
 ---
 
-# Issues
-
 Track bugs, features, and tasks with `wit issue`. Create, view, and manage issues without leaving your terminal.
 
 <Note>

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -3,8 +3,6 @@ title: "Platform Overview"
 description: "Self-hosted Git platform with wit"
 ---
 
-# wit Platform
-
 wit isn't just a Git client—it's a complete, self-hosted code collaboration platform that can replace GitHub for teams who want full control over their infrastructure.
 
 ## What's Included

--- a/docs/platform/pull-requests.mdx
+++ b/docs/platform/pull-requests.mdx
@@ -3,8 +3,6 @@ title: "Pull Requests"
 description: "Create and manage pull requests from the command line"
 ---
 
-# Pull Requests
-
 Manage pull requests directly from your terminal with `wit pr`. Create, review, merge, and close PRs without leaving your workflow.
 
 <Note>

--- a/docs/platform/self-hosting.mdx
+++ b/docs/platform/self-hosting.mdx
@@ -3,8 +3,6 @@ title: "Self-Hosting"
 description: "Run the complete wit platform locally with a single command"
 ---
 
-# Self-Hosting
-
 wit includes a complete self-hosted platform that provides Git hosting, pull requests, issues, and a web UI. Start everything with a single command.
 
 ## Quick Start

--- a/docs/platform/server.mdx
+++ b/docs/platform/server.mdx
@@ -3,8 +3,6 @@ title: "Git Server"
 description: "Host Git repositories with wit serve"
 ---
 
-# Git Server
-
 wit includes a built-in Git server that accepts push and pull over HTTP. Run your own GitHub-like infrastructure with a single command.
 
 ## Quick Start

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -3,8 +3,6 @@ title: Quickstart
 description: "Install wit and start using it in 5 minutes"
 ---
 
-# Quickstart
-
 ## Install
 
 Requires Node.js 22.13.0+.

--- a/docs/visual/graph.mdx
+++ b/docs/visual/graph.mdx
@@ -3,8 +3,6 @@ title: ASCII Graph
 description: "Quick commit visualization in the terminal"
 ---
 
-# ASCII Graph
-
 View your commit history as a visual graph directly in the terminal.
 
 ## Usage

--- a/docs/visual/overview.mdx
+++ b/docs/visual/overview.mdx
@@ -3,8 +3,6 @@ title: Visual Interfaces Overview
 description: "Built-in visual tools for version control"
 ---
 
-# Visual Interfaces
-
 wit includes powerful visual interfaces out of the box - no external tools required.
 
 ## Available Interfaces

--- a/docs/visual/terminal-ui.mdx
+++ b/docs/visual/terminal-ui.mdx
@@ -3,8 +3,6 @@ title: Terminal UI
 description: "Interactive terminal interface for version control"
 ---
 
-# Terminal UI
-
 The wit terminal UI provides a full-featured interface without leaving your terminal.
 
 ## Launch

--- a/docs/visual/web-ui.mdx
+++ b/docs/visual/web-ui.mdx
@@ -3,8 +3,6 @@ title: Web UI
 description: "Modern web dashboard for visual version control"
 ---
 
-# Web UI
-
 The wit web UI provides a modern, feature-rich interface for version control.
 
 ## Launch

--- a/docs/why-wit.mdx
+++ b/docs/why-wit.mdx
@@ -3,8 +3,6 @@ title: Why wit?
 description: "The problems we're solving and how"
 ---
 
-# Why wit?
-
 Git is powerful. It's also hostile.
 
 "Detached HEAD state" tells you nothing. The reflog is archaeology. `git checkout` does five different things. Every error message assumes you already know what went wrong.


### PR DESCRIPTION
## Summary

- Trimmed architecture overview from 495 lines to ~60 lines
- Removed verbose code snippets, redundant directory listings, and algorithm explanations
- Kept a concise system diagram, key component table, and brief explanations

The goal is to give readers a 30-second understanding of how the system is structured, not teach Git internals.