### PR TITLE
feat: add Journal tab to repository navigation

### DIFF
--- a/apps/web/src/routes/repo/components/repo-layout.tsx
+++ b/apps/web/src/routes/repo/components/repo-layout.tsx
@@ -13,6 +13,7 @@ import {
   Layers,
   MoreHorizontal,
   Sparkles,
+  BookOpen,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -227,6 +228,7 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     if (path.includes('/issues')) return 'issues';
     if (path.includes('/pulls') || path.includes('/pull/')) return 'pulls';
     if (path.includes('/stacks')) return 'stacks';
+    if (path.includes('/journal')) return 'journal';
     if (path.includes('/settings')) return 'settings';
     return 'code';
   };
@@ -423,6 +425,10 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
           <Link to={`/${owner}/${repo}/stacks`} className={tabClass('stacks')}>
             <Layers className="h-4 w-4" />
             <span className="hidden sm:inline">Stacks</span>
+          </Link>
+          <Link to={`/${owner}/${repo}/journal`} className={tabClass('journal')}>
+            <BookOpen className="h-4 w-4" />
+            <span className="hidden sm:inline">Journal</span>
           </Link>
           {authenticated && (
             <Link to={`/${owner}/${repo}/settings`} className={tabClass('settings')}>


### PR DESCRIPTION
## Summary

- Exposes the existing Journal functionality in the repository page navigation
- Adds a "Journal" tab with BookOpen icon between Stacks and Settings
- Updates the active tab detection to highlight the Journal tab when on journal pages

The journal feature (Notion-like documentation pages) was already fully implemented with routes, API endpoints, and UI pages, but was not discoverable from the main repo navigation.