### PR TITLE
fix: add proper cache invalidation for issue mutations

### DIFF
--- a/apps/web/src/routes/repo/issue-detail.tsx
+++ b/apps/web/src/routes/repo/issue-detail.tsx
@@ -113,7 +113,14 @@ export function IssueDetailPage() {
       });
     },
     onSettled: () => {
+      // Invalidate all issue-related queries to ensure UI is updated everywhere
       utils.issues.get.invalidate({ repoId: repoData?.repo.id!, number: issueNumber });
+      utils.issues.list.invalidate({ repoId: repoData?.repo.id! });
+      utils.issues.listGroupedByStatus.invalidate({ repoId: repoData?.repo.id! });
+      utils.issues.inboxAssignedToMe.invalidate();
+      utils.issues.inboxCreatedByMe.invalidate();
+      utils.issues.inboxParticipated.invalidate();
+      utils.issues.inboxSummary.invalidate();
     },
   });
 
@@ -153,7 +160,14 @@ export function IssueDetailPage() {
       });
     },
     onSettled: () => {
+      // Invalidate all issue-related queries to ensure UI is updated everywhere
       utils.issues.get.invalidate({ repoId: repoData?.repo.id!, number: issueNumber });
+      utils.issues.list.invalidate({ repoId: repoData?.repo.id! });
+      utils.issues.listGroupedByStatus.invalidate({ repoId: repoData?.repo.id! });
+      utils.issues.inboxAssignedToMe.invalidate();
+      utils.issues.inboxCreatedByMe.invalidate();
+      utils.issues.inboxParticipated.invalidate();
+      utils.issues.inboxSummary.invalidate();
     },
   });
 


### PR DESCRIPTION
## Summary

- Fixes UI not refreshing when moving issues on kanban board
- Fixes UI not refreshing when closing/reopening issues
- Fixes UI not refreshing when creating new issues

## Changes

### `apps/web/src/routes/repo/issue-detail.tsx`
- Updated `closeIssueMutation` and `reopenIssueMutation` to invalidate ALL issue-related queries:
  - `issues.get`, `issues.list`, `issues.listGroupedByStatus`
  - `issues.inboxAssignedToMe`, `issues.inboxCreatedByMe`, `issues.inboxParticipated`, `issues.inboxSummary`

### `apps/web/src/components/issue/kanban-board.tsx`
- Added **optimistic updates** for instant drag feedback
- Added rollback on error
- Added comprehensive query invalidation for list and inbox views

### `apps/web/src/routes/repo/issue-new.tsx`
- Added cache invalidation after creating a new issue

## Result

All issue views (list, kanban, inbox) now stay in sync after mutations.