### PR TITLE
feat: improve issues navigation UX with sub-tabs, breadcrumbs, and context preservation

### DIFF
--- a/apps/web/src/routes/repo/components/repo-layout.tsx
+++ b/apps/web/src/routes/repo/components/repo-layout.tsx
@@ -15,6 +15,8 @@ import {
   Sparkles,
   Maximize2,
   BookOpen,
+  FolderKanban,
+  RefreshCw,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -262,6 +264,21 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
   };
   const activeTab = getActiveTab();
 
+  // Determine active sub-tab for issues section
+  const getActiveIssuesSubTab = () => {
+    if (path.includes('/projects')) return 'projects';
+    if (path.includes('/cycles')) return 'cycles';
+    return 'issues';
+  };
+  const activeIssuesSubTab = getActiveIssuesSubTab();
+
+  const subTabClass = (tab: string) =>
+    `flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors ${
+      activeIssuesSubTab === tab
+        ? 'bg-primary/10 text-primary font-medium'
+        : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+    }`;
+
   const tabClass = (tab: string) =>
     `flex items-center gap-1.5 md:gap-2 px-2 md:px-4 py-2 border-b-2 text-sm transition-colors whitespace-nowrap ${
       activeTab === tab
@@ -488,6 +505,24 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
           )}
         </nav>
       </div>
+
+      {/* Sub-navigation for Issues section */}
+      {activeTab === 'issues' && (
+        <div className="flex items-center gap-2 -mt-2">
+          <Link to={`/${owner}/${repo}/issues`} className={subTabClass('issues')}>
+            <CircleDot className="h-4 w-4" />
+            Issues
+          </Link>
+          <Link to={`/${owner}/${repo}/projects`} className={subTabClass('projects')}>
+            <FolderKanban className="h-4 w-4" />
+            Projects
+          </Link>
+          <Link to={`/${owner}/${repo}/cycles`} className={subTabClass('cycles')}>
+            <RefreshCw className="h-4 w-4" />
+            Cycles
+          </Link>
+        </div>
+      )}
 
       {/* Page content */}
       {children}

--- a/apps/web/src/routes/repo/cycle-detail.tsx
+++ b/apps/web/src/routes/repo/cycle-detail.tsx
@@ -260,7 +260,7 @@ export function CycleDetailPage() {
               <Badge variant="secondary">{progress?.total || 0}</Badge>
             </h2>
             {authenticated && (
-              <Link to={`/${owner}/${repo}/issues/new`}>
+              <Link to={`/${owner}/${repo}/issues/new?cycle=${cycleId}`}>
                 <Button size="sm" variant="outline">
                   <Plus className="mr-2 h-4 w-4" />
                   Add Issue
@@ -284,7 +284,7 @@ export function CycleDetailPage() {
                 Add issues to this cycle to track sprint progress
               </p>
               {authenticated && (
-                <Link to={`/${owner}/${repo}/issues/new`}>
+                <Link to={`/${owner}/${repo}/issues/new?cycle=${cycleId}`}>
                   <Button>
                     <Plus className="mr-2 h-4 w-4" />
                     Create Issue

--- a/apps/web/src/routes/repo/issue-new.tsx
+++ b/apps/web/src/routes/repo/issue-new.tsx
@@ -1,22 +1,41 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { ChevronRight, FolderKanban, RefreshCw } from 'lucide-react';
 import { IssueForm } from '@/components/issue/issue-form';
 import { RepoLayout } from './components/repo-layout';
 import { Loading } from '@/components/ui/loading';
+import { Badge } from '@/components/ui/badge';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/lib/trpc';
 import { toastSuccess, toastError } from '@/components/ui/use-toast';
 
 export function NewIssuePage() {
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { data: session } = useSession();
   const authenticated = !!session?.user;
   const utils = trpc.useUtils();
 
+  // Get project/cycle context from URL params
+  const projectId = searchParams.get('project');
+  const cycleId = searchParams.get('cycle');
+
   // Fetch repository data to get the repo ID
   const { data: repoData, isLoading: repoLoading } = trpc.repos.get.useQuery(
     { owner: owner!, repo: repo! },
     { enabled: !!owner && !!repo }
+  );
+
+  // Fetch project details if context exists
+  const { data: project } = trpc.projects.get.useQuery(
+    { projectId: projectId! },
+    { enabled: !!projectId }
+  );
+
+  // Fetch cycle details if context exists
+  const { data: cycle } = trpc.cycles.get.useQuery(
+    { cycleId: cycleId! },
+    { enabled: !!cycleId }
   );
 
   // Create issue mutation
@@ -51,6 +70,8 @@ export function NewIssuePage() {
       repoId: repoData.repo.id,
       title: data.title,
       body: data.body,
+      projectId: projectId || undefined,
+      cycleId: cycleId || undefined,
     });
   };
 
@@ -72,9 +93,71 @@ export function NewIssuePage() {
     );
   }
 
+  // Build the back URL with context
+  const getBackUrl = () => {
+    if (projectId) return `/${owner}/${repo}/issues?section=project&project=${projectId}`;
+    if (cycleId) return `/${owner}/${repo}/issues?section=cycle&cycle=${cycleId}`;
+    return `/${owner}/${repo}/issues`;
+  };
+
   return (
     <RepoLayout owner={owner!} repo={repo!}>
-      <div className="max-w-3xl">
+      <div className="max-w-3xl space-y-4">
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-2 text-sm">
+          <Link 
+            to={`/${owner}/${repo}/issues`}
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Issues
+          </Link>
+          {(project || cycle) && (
+            <>
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              <Link 
+                to={getBackUrl()}
+                className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {project ? (
+                  <>
+                    <FolderKanban className="h-4 w-4" />
+                    {project.icon && <span>{project.icon}</span>}
+                    {project.name}
+                  </>
+                ) : cycle ? (
+                  <>
+                    <RefreshCw className="h-4 w-4" />
+                    {cycle.name}
+                  </>
+                ) : null}
+              </Link>
+            </>
+          )}
+          <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          <span className="text-foreground font-medium">New Issue</span>
+        </div>
+
+        {/* Context indicator */}
+        {(project || cycle) && (
+          <div className="flex items-center gap-2 p-3 bg-muted/50 rounded-lg border">
+            <span className="text-sm text-muted-foreground">Creating issue in:</span>
+            <Badge variant="secondary" className="gap-1.5">
+              {project ? (
+                <>
+                  <FolderKanban className="h-3.5 w-3.5" />
+                  {project.icon && <span>{project.icon}</span>}
+                  {project.name}
+                </>
+              ) : cycle ? (
+                <>
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  {cycle.name}
+                </>
+              ) : null}
+            </Badge>
+          </div>
+        )}
+
         <IssueForm
           onSubmit={handleSubmit}
           isLoading={createIssueMutation.isPending}

--- a/apps/web/src/routes/repo/project-detail.tsx
+++ b/apps/web/src/routes/repo/project-detail.tsx
@@ -279,7 +279,7 @@ export function ProjectDetailPage() {
                   Add issues to this project to track progress
                 </p>
                 {authenticated && (
-                  <Link to={`/${owner}/${repo}/issues/new`}>
+                  <Link to={`/${owner}/${repo}/issues/new?project=${projectId}`}>
                     <Button>
                       <Plus className="mr-2 h-4 w-4" />
                       Create Issue


### PR DESCRIPTION
## Summary

Improves the navigation UX for the issues page, making it easier to navigate between projects, cycles, and issues.

### Changes

- **Sub-tabs for Issues/Projects/Cycles**: Added a secondary navigation bar under the "Issues" tab that shows Issues, Projects, and Cycles sub-tabs for better discoverability
- **Breadcrumb navigation**: Added breadcrumbs when filtering issues by project or cycle (e.g., `All Issues > Project Name ×`) with a quick clear button
- **Context switcher dropdown**: The issues header title is now a dropdown that allows quick switching between All Issues, any project, or any cycle
- **Context-preserved issue creation**: "New Issue" buttons now pass project/cycle context via URL params, and the new issue page shows the context with a banner
- **Back navigation from issue detail**: Added breadcrumbs and clickable project/cycle badges on the issue detail page to navigate back to the filtered view

### Files Changed

- `apps/web/src/routes/repo/components/repo-layout.tsx` - Added sub-tabs
- `apps/web/src/routes/repo/issues.tsx` - Added breadcrumbs, context switcher, and context-preserved links
- `apps/web/src/routes/repo/issue-new.tsx` - Handle project/cycle context from URL and display indicator
- `apps/web/src/routes/repo/issue-detail.tsx` - Added breadcrumbs and project/cycle badges
- `apps/web/src/routes/repo/project-detail.tsx` - Pass project context to new issue link
- `apps/web/src/routes/repo/cycle-detail.tsx` - Pass cycle context to new issue links