### PR TITLE
fix: improve toast readability and add project editing to issues

### DIFF
--- a/apps/web/src/components/issue/project-picker.tsx
+++ b/apps/web/src/components/issue/project-picker.tsx
@@ -1,0 +1,88 @@
+import { Check, FolderKanban, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface Project {
+  id: string;
+  name: string;
+  icon: string | null;
+}
+
+interface ProjectPickerProps {
+  availableProjects: Project[];
+  selectedProject: Project | null;
+  onProjectChange: (project: Project | null) => void;
+  isLoading?: boolean;
+}
+
+export function ProjectPicker({
+  availableProjects,
+  selectedProject,
+  onProjectChange,
+  isLoading,
+}: ProjectPickerProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">Project</span>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-6 gap-1" disabled={isLoading}>
+              <FolderKanban className="h-3 w-3" />
+              {isLoading ? 'Saving...' : 'Edit'}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-64">
+            {/* Option to remove from project */}
+            {selectedProject && (
+              <DropdownMenuItem
+                onClick={() => onProjectChange(null)}
+                className="flex items-center gap-2 text-muted-foreground"
+              >
+                <X className="h-3 w-3" />
+                <span>Remove from project</span>
+              </DropdownMenuItem>
+            )}
+            {availableProjects.length === 0 ? (
+              <div className="px-2 py-4 text-center text-sm text-muted-foreground">
+                No projects available
+              </div>
+            ) : (
+              availableProjects.map((project) => {
+                const isSelected = selectedProject?.id === project.id;
+                return (
+                  <DropdownMenuItem
+                    key={project.id}
+                    onClick={() => onProjectChange(isSelected ? null : project)}
+                    className="flex items-center gap-2"
+                  >
+                    {project.icon && <span>{project.icon}</span>}
+                    {!project.icon && <FolderKanban className="h-3 w-3" />}
+                    <span className="flex-1">{project.name}</span>
+                    {isSelected && <Check className="h-4 w-4" />}
+                  </DropdownMenuItem>
+                );
+              })
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Selected project display */}
+      {selectedProject ? (
+        <div className="flex items-center gap-2 text-sm">
+          {selectedProject.icon && <span>{selectedProject.icon}</span>}
+          {!selectedProject.icon && <FolderKanban className="h-3 w-3 text-muted-foreground" />}
+          <span>{selectedProject.name}</span>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No project</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -27,10 +27,10 @@ const toastVariants = cva(
     variants: {
       variant: {
         default: 'border-border bg-background text-foreground',
-        success: 'border-success/30 bg-success/10 text-success-foreground',
-        destructive: 'border-destructive/30 bg-destructive/10 text-destructive',
-        warning: 'border-warning/30 bg-warning/10 text-warning-foreground',
-        info: 'border-info/30 bg-info/10 text-info-foreground',
+        success: 'border-success/30 bg-success/10 text-foreground',
+        destructive: 'border-destructive/30 bg-destructive/10 text-foreground',
+        warning: 'border-warning/30 bg-warning/10 text-foreground',
+        info: 'border-info/30 bg-info/10 text-foreground',
       },
     },
     defaultVariants: {

--- a/apps/web/src/routes/repo/project-detail.tsx
+++ b/apps/web/src/routes/repo/project-detail.tsx
@@ -124,7 +124,7 @@ export function ProjectDetailPage() {
 
   const statusConfig = STATUS_CONFIG[project.status] || STATUS_CONFIG.backlog;
   const progressPercent = progress
-    ? Math.round((progress.completed / Math.max(progress.total, 1)) * 100)
+    ? Math.round((progress.completedIssues / Math.max(progress.totalIssues, 1)) * 100)
     : 0;
 
   // Group issues by status for Kanban

--- a/apps/web/src/routes/repo/projects.tsx
+++ b/apps/web/src/routes/repo/projects.tsx
@@ -282,7 +282,7 @@ function ProjectCard({ project, owner, repo }: ProjectCardProps) {
   );
 
   const progressPercent = progress
-    ? Math.round((progress.completed / Math.max(progress.total, 1)) * 100)
+    ? Math.round((progress.completedIssues / Math.max(progress.totalIssues, 1)) * 100)
     : 0;
 
   return (
@@ -341,7 +341,7 @@ function ProjectCard({ project, owner, repo }: ProjectCardProps) {
           <>
             <span className="flex items-center gap-1">
               <Target className="h-3 w-3" />
-              {progress.completed}/{progress.total} issues
+              {progress.completedIssues}/{progress.totalIssues} issues
             </span>
           </>
         )}


### PR DESCRIPTION
## Summary

- Fix toast text colors to use `text-foreground` for better contrast in both light and dark modes
- Fix NaN display in project cards by using correct field names (`totalIssues`/`completedIssues` instead of `total`/`completed`)
- Add `ProjectPicker` component to issue detail sidebar, enabling users to assign/change/remove project from issues

## Changes

### Toast Readability Fix
The toast variants were using specific foreground colors (`text-success-foreground`, `text-warning-foreground`, etc.) that had poor contrast against the light tinted backgrounds. Changed all variants to use `text-foreground` for consistent readability.

### Project Progress NaN Fix
The backend `getProgress` method returns `totalIssues` and `completedIssues`, but the frontend was accessing `total` and `completed`, causing `undefined / undefined = NaN`.

### Project Picker
Added a new `ProjectPicker` component that allows users to:
- See the current project assignment on an issue
- Select a different project from a dropdown
- Remove the issue from a project entirely

Uses the existing `trpc.issues.assignToProject` API endpoint.