### PR TITLE
feat(web): add datepicker component and replace native date inputs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "date-fns": "^4.1.0",
     "lucide-react": "^0.468.0",
     "react": "^19.0.0",
+    "react-day-picker": "^9.13.0",
     "react-dom": "^19.0.0",
     "react-hotkeys-hook": "^5.2.1",
     "react-markdown": "^9.0.1",

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn('p-3', className)}
+      classNames={{
+        months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
+        month: 'space-y-4',
+        month_caption: 'flex justify-center pt-1 relative items-center',
+        caption_label: 'text-sm font-medium',
+        nav: 'space-x-1 flex items-center',
+        button_previous: cn(
+          buttonVariants({ variant: 'outline' }),
+          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1'
+        ),
+        button_next: cn(
+          buttonVariants({ variant: 'outline' }),
+          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1'
+        ),
+        month_grid: 'w-full border-collapse space-y-1',
+        weekdays: 'flex',
+        weekday:
+          'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
+        week: 'flex w-full mt-2',
+        day: cn(
+          'relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected].day-range-end)]:rounded-r-md',
+          props.mode === 'range'
+            ? '[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md'
+            : '[&:has([aria-selected])]:rounded-md'
+        ),
+        day_button: cn(
+          buttonVariants({ variant: 'ghost' }),
+          'h-9 w-9 p-0 font-normal aria-selected:opacity-100 rounded-md'
+        ),
+        range_start: 'day-range-start',
+        range_end: 'day-range-end',
+        selected:
+          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+        today: 'bg-accent text-accent-foreground',
+        outside:
+          'day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground',
+        disabled: 'text-muted-foreground opacity-50',
+        range_middle:
+          'aria-selected:bg-accent aria-selected:text-accent-foreground',
+        hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation }) => {
+          const Icon = orientation === 'left' ? ChevronLeft : ChevronRight;
+          return <Icon className="h-4 w-4" />;
+        },
+      }}
+      {...props}
+    />
+  );
+}
+Calendar.displayName = 'Calendar';
+
+export { Calendar };

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -1,0 +1,158 @@
+import * as React from 'react';
+import { format } from 'date-fns';
+import { Calendar as CalendarIcon } from 'lucide-react';
+import type { DateRange } from 'react-day-picker';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+export interface DatePickerProps {
+  /** The selected date */
+  date?: Date;
+  /** Callback when date changes */
+  onDateChange?: (date: Date | undefined) => void;
+  /** Placeholder text when no date is selected */
+  placeholder?: string;
+  /** Custom date format string (date-fns format) */
+  dateFormat?: string;
+  /** Disable the date picker */
+  disabled?: boolean;
+  /** Additional class names for the trigger button */
+  className?: string;
+  /** Minimum selectable date */
+  fromDate?: Date;
+  /** Maximum selectable date */
+  toDate?: Date;
+  /** Dates that should be disabled */
+  disabledDates?: Date[] | ((date: Date) => boolean);
+}
+
+export function DatePicker({
+  date,
+  onDateChange,
+  placeholder = 'Pick a date',
+  dateFormat = 'PPP',
+  disabled = false,
+  className,
+  fromDate,
+  toDate,
+  disabledDates,
+}: DatePickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const handleSelect = (selectedDate: Date | undefined) => {
+    onDateChange?.(selectedDate);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          disabled={disabled}
+          className={cn(
+            'w-[240px] justify-start text-left font-normal',
+            !date && 'text-muted-foreground',
+            className
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {date ? format(date, dateFormat) : <span>{placeholder}</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={handleSelect}
+          initialFocus
+          fromDate={fromDate}
+          toDate={toDate}
+          disabled={disabledDates}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export interface DateRangePickerProps {
+  /** The selected date range */
+  dateRange?: DateRange;
+  /** Callback when date range changes */
+  onDateRangeChange?: (range: DateRange | undefined) => void;
+  /** Placeholder text when no date is selected */
+  placeholder?: string;
+  /** Custom date format string (date-fns format) */
+  dateFormat?: string;
+  /** Disable the date picker */
+  disabled?: boolean;
+  /** Additional class names for the trigger button */
+  className?: string;
+  /** Number of months to display */
+  numberOfMonths?: number;
+  /** Minimum selectable date */
+  fromDate?: Date;
+  /** Maximum selectable date */
+  toDate?: Date;
+}
+
+export function DateRangePicker({
+  dateRange,
+  onDateRangeChange,
+  placeholder = 'Pick a date range',
+  dateFormat = 'LLL dd, y',
+  disabled = false,
+  className,
+  numberOfMonths = 2,
+  fromDate,
+  toDate,
+}: DateRangePickerProps) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          disabled={disabled}
+          className={cn(
+            'w-[300px] justify-start text-left font-normal',
+            !dateRange?.from && 'text-muted-foreground',
+            className
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {dateRange?.from ? (
+            dateRange.to ? (
+              <>
+                {format(dateRange.from, dateFormat)} -{' '}
+                {format(dateRange.to, dateFormat)}
+              </>
+            ) : (
+              format(dateRange.from, dateFormat)
+            )
+          ) : (
+            <span>{placeholder}</span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="range"
+          defaultMonth={dateRange?.from}
+          selected={dateRange}
+          onSelect={onDateRangeChange}
+          numberOfMonths={numberOfMonths}
+          fromDate={fromDate}
+          toDate={toDate}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/routes/repo/cycles.tsx
+++ b/apps/web/src/routes/repo/cycles.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { DatePicker } from '@/components/ui/date-picker';
 import { RepoLayout } from './components/repo-layout';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/lib/trpc';
@@ -39,10 +40,14 @@ import { toastSuccess, toastError } from '@/components/ui/use-toast';
 export function CyclesPage() {
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
   const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [newCycle, setNewCycle] = useState({ 
+  const [newCycle, setNewCycle] = useState<{ 
+    name: string; 
+    startDate: Date | undefined; 
+    endDate: Date | undefined;
+  }>({ 
     name: '', 
-    startDate: '', 
-    endDate: '' 
+    startDate: undefined, 
+    endDate: undefined,
   });
   const { data: session } = useSession();
   const authenticated = !!session?.user;
@@ -78,7 +83,7 @@ export function CyclesPage() {
       utils.cycles.list.invalidate({ repoId: repoData?.repo.id! });
       utils.cycles.getCurrent.invalidate({ repoId: repoData?.repo.id! });
       setShowCreateDialog(false);
-      setNewCycle({ name: '', startDate: '', endDate: '' });
+      setNewCycle({ name: '', startDate: undefined, endDate: undefined });
       toastSuccess({ title: 'Cycle created successfully' });
     },
     onError: (error) => {
@@ -93,8 +98,8 @@ export function CyclesPage() {
     createMutation.mutate({
       repoId: repoData.repo.id,
       name: newCycle.name.trim(),
-      startDate: newCycle.startDate,
-      endDate: newCycle.endDate,
+      startDate: newCycle.startDate.toISOString().split('T')[0],
+      endDate: newCycle.endDate.toISOString().split('T')[0],
     });
   };
 
@@ -263,20 +268,22 @@ export function CyclesPage() {
             <div className="grid gap-4 grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="startDate">Start Date</Label>
-                <Input
-                  id="startDate"
-                  type="date"
-                  value={newCycle.startDate}
-                  onChange={(e) => setNewCycle({ ...newCycle, startDate: e.target.value })}
+                <DatePicker
+                  date={newCycle.startDate}
+                  onDateChange={(date) => setNewCycle({ ...newCycle, startDate: date })}
+                  placeholder="Select start date"
+                  toDate={newCycle.endDate}
+                  className="w-full"
                 />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="endDate">End Date</Label>
-                <Input
-                  id="endDate"
-                  type="date"
-                  value={newCycle.endDate}
-                  onChange={(e) => setNewCycle({ ...newCycle, endDate: e.target.value })}
+                <DatePicker
+                  date={newCycle.endDate}
+                  onDateChange={(date) => setNewCycle({ ...newCycle, endDate: date })}
+                  placeholder="Select end date"
+                  fromDate={newCycle.startDate}
+                  className="w-full"
                 />
               </div>
             </div>

--- a/apps/web/src/routes/repo/milestones/index.tsx
+++ b/apps/web/src/routes/repo/milestones/index.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { DatePicker } from '@/components/ui/date-picker';
 import { Loading } from '@/components/ui/loading';
 import { EmptyState } from '@/components/ui/empty-state';
 import { RepoLayout } from '../components/repo-layout';
@@ -26,13 +27,13 @@ import { formatDate, cn } from '@/lib/utils';
 interface MilestoneFormData {
   title: string;
   description: string;
-  dueDate: string;
+  dueDate: Date | undefined;
 }
 
 const DEFAULT_FORM: MilestoneFormData = {
   title: '',
   description: '',
-  dueDate: '',
+  dueDate: undefined,
 };
 
 export function MilestonesPage() {
@@ -116,9 +117,7 @@ export function MilestonesPage() {
     setFormData({
       title: milestone.title,
       description: milestone.description || '',
-      dueDate: milestone.dueDate
-        ? new Date(milestone.dueDate).toISOString().split('T')[0]
-        : '',
+      dueDate: milestone.dueDate ? new Date(milestone.dueDate) : undefined,
     });
     setIsDialogOpen(true);
   };
@@ -138,7 +137,7 @@ export function MilestonesPage() {
       repoId: repoData.repo.id,
       title: formData.title.trim(),
       description: formData.description.trim() || undefined,
-      dueDate: formData.dueDate ? new Date(formData.dueDate) : undefined,
+      dueDate: formData.dueDate,
     };
 
     if (editingMilestone) {
@@ -259,11 +258,11 @@ export function MilestonesPage() {
 
                     <div className="space-y-2">
                       <Label htmlFor="dueDate">Due date (optional)</Label>
-                      <Input
-                        id="dueDate"
-                        type="date"
-                        value={formData.dueDate}
-                        onChange={(e) => setFormData({ ...formData, dueDate: e.target.value })}
+                      <DatePicker
+                        date={formData.dueDate}
+                        onDateChange={(date) => setFormData({ ...formData, dueDate: date })}
+                        placeholder="Select due date"
+                        className="w-full"
                       />
                     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "date-fns": "^4.1.0",
         "lucide-react": "^0.468.0",
         "react": "^19.0.0",
+        "react-day-picker": "^9.13.0",
         "react-dom": "^19.0.0",
         "react-hotkeys-hook": "^5.2.1",
         "react-markdown": "^9.0.1",
@@ -705,6 +706,12 @@
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
       "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",
@@ -7038,6 +7045,12 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -10922,6 +10935,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.13.0.tgz",
+      "integrity": "sha512-euzj5Hlq+lOHqI53NiuNhCP8HWgsPf/bBAVijR50hNaY1XwjKjShAnIe8jm8RD2W9IJUvihDIZ+KrmqfFzNhFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {


### PR DESCRIPTION
## Summary

- Add a custom DatePicker component using react-day-picker v9 that matches the existing shadcn/ui design system
- Replace all native HTML date inputs with the new styled DatePicker

## Changes

### New Components
- `apps/web/src/components/ui/calendar.tsx` - Base calendar component with Tailwind styling
- `apps/web/src/components/ui/date-picker.tsx` - DatePicker and DateRangePicker with popover

### Updated Pages
- **Cycles page** (`cycles.tsx`): Start/end date pickers with date constraints
- **Milestones page** (`milestones/index.tsx`): Due date picker

## Features
- Popover-based calendar picker
- Date range support for cycles
- Min/max date constraints (e.g., end date can't be before start date)
- Consistent styling with existing UI components
- Full keyboard navigation support