### PR TITLE
fix: improve journal UI layout and fix double scrolling issues

### DIFF
--- a/apps/web/src/components/editor/block-editor/block-item.tsx
+++ b/apps/web/src/components/editor/block-editor/block-item.tsx
@@ -72,6 +72,7 @@ interface BlockItemProps {
   onSlashCommand: (query: string, cursorPosition: { top: number; left: number }) => void;
   onCloseSlashMenu: () => void;
   dragHandleProps?: any;
+  placeholder?: string;
 }
 
 export function BlockItem({
@@ -88,6 +89,7 @@ export function BlockItem({
   onSlashCommand,
   onCloseSlashMenu,
   dragHandleProps,
+  placeholder: customPlaceholder,
 }: BlockItemProps) {
   const [isHovered, setIsHovered] = useState(false);
   const [showColorPicker, setShowColorPicker] = useState(false);
@@ -452,7 +454,7 @@ export function BlockItem({
         return (
           <textarea
             {...commonInputProps}
-            placeholder="Type '/' for commands..."
+            placeholder={customPlaceholder || "Type '/' for commands..."}
             className={cn(commonInputProps.className, 'leading-relaxed')}
           />
         );

--- a/apps/web/src/components/editor/block-editor/index.tsx
+++ b/apps/web/src/components/editor/block-editor/index.tsx
@@ -509,7 +509,7 @@ export function BlockEditor({
     >
       {/* Blocks */}
       <div className="space-y-0.5">
-        {blocks.map((block) => (
+        {blocks.map((block, index) => (
           <BlockItem
             key={block.id}
             block={block}
@@ -538,16 +538,10 @@ export function BlockEditor({
             onCloseSlashMenu={() =>
               setSlashMenu((prev) => ({ ...prev, isOpen: false }))
             }
+            placeholder={index === 0 && blocks.length === 1 ? placeholder : undefined}
           />
         ))}
       </div>
-
-      {/* Empty state / placeholder */}
-      {blocks.length === 1 && blocks[0].content === '' && placeholder && (
-        <div className="absolute top-0 left-0 text-muted-foreground/40 pointer-events-none pl-10">
-          {placeholder}
-        </div>
-      )}
 
       {/* Slash command menu */}
       <SlashMenu

--- a/apps/web/src/routes/repo/journal/index.tsx
+++ b/apps/web/src/routes/repo/journal/index.tsx
@@ -78,10 +78,10 @@ export function JournalPage() {
   if (isLoading) {
     return (
       <RepoLayout owner={owner!} repo={repo!}>
-        <div className="flex h-[calc(100vh-200px)]">
+        <div className="flex min-h-[400px] rounded-lg border bg-card overflow-hidden">
           {/* Sidebar skeleton */}
-          <div className="w-64 border-r p-3 space-y-2">
-            {[...Array(8)].map((_, i) => (
+          <div className="w-60 border-r p-3 space-y-2">
+            {[...Array(5)].map((_, i) => (
               <div key={i} className="h-7 rounded bg-muted/50 animate-pulse" />
             ))}
           </div>
@@ -99,14 +99,14 @@ export function JournalPage() {
 
   return (
     <RepoLayout owner={owner!} repo={repo!}>
-      <div className="flex h-[calc(100vh-200px)] -mx-6 -mt-6">
-        {/* Notion-style sidebar */}
-        <div className="w-64 border-r bg-muted/30 flex flex-col">
-          {/* Search */}
-          <div className="p-2 border-b">
+      <div className="flex min-h-[500px] rounded-lg border bg-card overflow-hidden">
+        {/* Sidebar */}
+        <div className="w-60 border-r bg-muted/20 flex flex-col">
+          {/* Header with search and new button */}
+          <div className="p-3 border-b flex items-center gap-2">
             <div
               className={cn(
-                'flex items-center gap-2 px-2 py-1.5 rounded-md transition-all cursor-text',
+                'flex-1 flex items-center gap-2 px-2 py-1.5 rounded-md transition-all cursor-text',
                 isSearching
                   ? 'bg-background ring-1 ring-ring'
                   : 'hover:bg-muted/50'
@@ -127,6 +127,16 @@ export function JournalPage() {
                 <span className="text-sm text-muted-foreground">Search</span>
               )}
             </div>
+            {authenticated && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0 flex-shrink-0"
+                onClick={handleNewPage}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            )}
           </div>
 
           {/* Page tree */}
@@ -144,33 +154,16 @@ export function JournalPage() {
                   />
                 ))
               ) : searchQuery ? (
-                <div className="px-2 py-8 text-center">
+                <div className="px-2 py-6 text-center">
                   <p className="text-sm text-muted-foreground">No results</p>
                 </div>
-              ) : (
-                <div className="px-2 py-8 text-center">
-                  <p className="text-sm text-muted-foreground">No pages yet</p>
-                </div>
-              )}
+              ) : null}
             </div>
           </div>
-
-          {/* New page button */}
-          {authenticated && (
-            <div className="p-2 border-t">
-              <button
-                onClick={handleNewPage}
-                className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
-              >
-                <Plus className="h-4 w-4" />
-                New page
-              </button>
-            </div>
-          )}
         </div>
 
-        {/* Main content area - empty state */}
-        <div className="flex-1 flex items-center justify-center bg-background">
+        {/* Main content area */}
+        <div className="flex-1 flex items-center justify-center bg-background p-6">
           <EmptyStateContent
             owner={owner!}
             repo={repo!}

--- a/apps/web/src/routes/repo/journal/page-detail.tsx
+++ b/apps/web/src/routes/repo/journal/page-detail.tsx
@@ -6,7 +6,6 @@ import {
   Clock,
   Star,
   MoreHorizontal,
-  ImagePlus,
   Smile,
   History,
   Copy,
@@ -66,7 +65,6 @@ export function JournalPageDetail() {
   const [editedTitle, setEditedTitle] = useState('');
   const [showIconPicker, setShowIconPicker] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
   const [pendingContent, setPendingContent] = useState<string | null>(null);
 
   const titleRef = useRef<HTMLTextAreaElement>(null);
@@ -205,12 +203,12 @@ export function JournalPageDetail() {
     return (
       <RepoLayout owner={owner!} repo={repo!}>
         <JournalDetailLayout tree={tree || []} owner={owner!} repo={repo!} authenticated={authenticated} currentSlug={slug}>
-          <div className="max-w-3xl mx-auto px-16 py-24">
+          <div className="max-w-2xl mx-auto px-6 py-8">
             <div className="space-y-4">
-              <div className="h-12 w-12 rounded bg-muted animate-pulse" />
-              <div className="h-10 w-2/3 rounded bg-muted animate-pulse" />
-              <div className="space-y-2 pt-8">
-                {[...Array(6)].map((_, i) => (
+              <div className="h-10 w-10 rounded bg-muted animate-pulse" />
+              <div className="h-8 w-2/3 rounded bg-muted animate-pulse" />
+              <div className="space-y-2 pt-4">
+                {[...Array(4)].map((_, i) => (
                   <div
                     key={i}
                     className="h-5 rounded bg-muted/50 animate-pulse"
@@ -229,11 +227,11 @@ export function JournalPageDetail() {
     return (
       <RepoLayout owner={owner!} repo={repo!}>
         <JournalDetailLayout tree={tree || []} owner={owner!} repo={repo!} authenticated={authenticated} currentSlug={slug}>
-          <div className="flex-1 flex items-center justify-center">
+          <div className="flex-1 flex items-center justify-center p-6">
             <div className="text-center">
-              <div className="text-6xl mb-6">🔍</div>
+              <div className="text-5xl mb-4">🔍</div>
               <h2 className="text-xl font-medium mb-2">Page not found</h2>
-              <p className="text-muted-foreground mb-6">
+              <p className="text-muted-foreground mb-4">
                 This page doesn't exist or has been deleted.
               </p>
               <Link to={`/${owner}/${repo}/journal`}>
@@ -259,8 +257,8 @@ export function JournalPageDetail() {
       >
         <div className="flex-1 overflow-y-auto">
           {/* Cover image area */}
-          {page.coverImage ? (
-            <div className="h-48 relative group">
+          {page.coverImage && (
+            <div className="h-32 relative group">
               <img
                 src={page.coverImage}
                 alt=""
@@ -277,32 +275,15 @@ export function JournalPageDetail() {
                 </div>
               )}
             </div>
-          ) : canEdit ? (
-            <div
-              className="h-12 group relative"
-              onMouseEnter={() => setIsHeaderHovered(true)}
-              onMouseLeave={() => setIsHeaderHovered(false)}
-            >
-              {isHeaderHovered && (
-                <div className="absolute top-4 left-16 flex items-center gap-2 text-sm text-muted-foreground">
-                  <button className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted transition-colors">
-                    <ImagePlus className="h-4 w-4" />
-                    Add cover
-                  </button>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="h-12" />
           )}
 
           {/* Main content area */}
-          <div className="max-w-3xl mx-auto px-16 pb-24">
+          <div className="max-w-2xl mx-auto px-6 py-6">
             {/* Icon */}
-            <div className="relative -mt-8 mb-4">
+            <div className="relative mb-4">
               {page.icon ? (
                 <div className="relative inline-block group">
-                  <span className="text-7xl cursor-pointer" onClick={() => canEdit && setShowIconPicker(true)}>
+                  <span className="text-5xl cursor-pointer" onClick={() => canEdit && setShowIconPicker(true)}>
                     {page.icon}
                   </span>
                   {canEdit && (
@@ -358,17 +339,16 @@ export function JournalPageDetail() {
                 onChange={handleTitleChange}
                 onBlur={handleTitleBlur}
                 placeholder="Untitled"
-                className="w-full text-4xl font-bold bg-transparent border-0 outline-none resize-none placeholder:text-muted-foreground/50 mb-2"
+                className="w-full text-3xl font-bold bg-transparent border-0 outline-none resize-none placeholder:text-muted-foreground/50 mb-2"
                 rows={1}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault();
-                    // Let focus move to block editor naturally
                   }
                 }}
               />
             ) : (
-              <h1 className="text-4xl font-bold mb-2">
+              <h1 className="text-3xl font-bold mb-2">
                 {page.title || 'Untitled'}
               </h1>
             )}
@@ -485,22 +465,20 @@ export function JournalPageDetail() {
             </div>
 
             {/* Content - Block Editor */}
-            <div className="relative">
-              <BlockEditor
-                value={editedContent}
-                onChange={handleContentChange}
-                placeholder="Type '/' for commands..."
-                readOnly={!canEdit}
-                autoFocus={false}
-              />
-              
-              {/* Save indicator */}
-              {pendingContent !== null && (
-                <div className="absolute top-0 right-0 text-xs text-muted-foreground">
-                  Saving...
-                </div>
-              )}
-            </div>
+            <BlockEditor
+              value={editedContent}
+              onChange={handleContentChange}
+              placeholder="Start writing or type '/' for commands..."
+              readOnly={!canEdit}
+              autoFocus={false}
+            />
+            
+            {/* Save indicator */}
+            {pendingContent !== null && (
+              <div className="text-xs text-muted-foreground mt-2">
+                Saving...
+              </div>
+            )}
           </div>
         </div>
 
@@ -556,21 +534,25 @@ function JournalDetailLayout({
   currentSlug,
 }: JournalDetailLayoutProps) {
   const navigate = useNavigate();
-  const sidebarWidth = 260;
 
   return (
-    <div className="flex h-[calc(100vh-200px)] -mx-6 -mt-6">
+    <div className="flex min-h-[500px] rounded-lg border bg-card overflow-hidden">
       {/* Sidebar */}
-      <div
-        className="border-r bg-muted/20 flex flex-col"
-        style={{ width: sidebarWidth }}
-      >
+      <div className="w-56 border-r bg-muted/20 flex flex-col flex-shrink-0">
         {/* Sidebar header */}
-        <div className="px-3 py-2 border-b">
+        <div className="px-3 py-2 border-b flex items-center justify-between">
           <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
             <FileText className="h-4 w-4" />
-            <span>Journal</span>
+            <span>Pages</span>
           </div>
+          {authenticated && (
+            <button
+              onClick={() => navigate(`/${owner}/${repo}/journal/new`)}
+              className="h-6 w-6 flex items-center justify-center rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <span className="text-lg leading-none">+</span>
+            </button>
+          )}
         </div>
 
         {/* Page tree */}
@@ -594,21 +576,6 @@ function JournalDetailLayout({
             )}
           </div>
         </div>
-
-        {/* New page button */}
-        {authenticated && (
-          <div className="px-2 py-2 border-t">
-            <button
-              onClick={() => navigate(`/${owner}/${repo}/journal/new`)}
-              className="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-            >
-              <span className="flex items-center justify-center w-5 h-5 rounded border border-dashed border-muted-foreground/30">
-                <span className="text-xs">+</span>
-              </span>
-              New page
-            </button>
-          </div>
-        )}
       </div>
 
       {/* Main content */}

--- a/apps/web/src/routes/repo/journal/page-new.tsx
+++ b/apps/web/src/routes/repo/journal/page-new.tsx
@@ -3,16 +3,13 @@ import { useParams, Link, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   FileText,
   Smile,
-  ImagePlus,
   Trash2,
-  ChevronRight,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { RepoLayout } from '../components/repo-layout';
 import { useSession } from '@/lib/auth-client';
 import { trpc } from '@/lib/trpc';
 import { useToast } from '@/components/ui/use-toast';
-import { cn } from '@/lib/utils';
 import { BlockEditor } from '@/components/editor/block-editor';
 
 // Common page icons
@@ -35,7 +32,6 @@ export function NewJournalPage() {
   const [content, setContent] = useState('');
   const [icon, setIcon] = useState('');
   const [showIconPicker, setShowIconPicker] = useState(false);
-  const [isHeaderHovered, setIsHeaderHovered] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
   const titleRef = useRef<HTMLTextAreaElement>(null);
@@ -49,12 +45,6 @@ export function NewJournalPage() {
   const { data: repoData, isLoading: repoLoading } = trpc.repos.get.useQuery(
     { owner: owner!, repo: repo! },
     { enabled: !!owner && !!repo }
-  );
-
-  // Fetch page tree for sidebar
-  const { data: tree } = trpc.journal.tree.useQuery(
-    { repoId: repoData?.repo.id! },
-    { enabled: !!repoData?.repo.id }
   );
 
   // Create mutation
@@ -117,11 +107,11 @@ export function NewJournalPage() {
   if (!authenticated) {
     return (
       <RepoLayout owner={owner!} repo={repo!}>
-        <div className="flex h-[calc(100vh-200px)] items-center justify-center">
-          <div className="text-center">
-            <div className="text-6xl mb-6">🔒</div>
+        <div className="flex min-h-[400px] items-center justify-center rounded-lg border bg-card">
+          <div className="text-center p-6">
+            <div className="text-5xl mb-4">🔒</div>
             <h2 className="text-xl font-medium mb-2">Sign in required</h2>
-            <p className="text-muted-foreground mb-6">
+            <p className="text-muted-foreground mb-4">
               You need to sign in to create journal pages.
             </p>
             <Link to="/login">
@@ -136,14 +126,11 @@ export function NewJournalPage() {
   if (repoLoading) {
     return (
       <RepoLayout owner={owner!} repo={repo!}>
-        <div className="flex h-[calc(100vh-200px)] -mx-6 -mt-6">
-          <div className="w-64 border-r bg-muted/30 p-2 space-y-2">
-            {[...Array(5)].map((_, i) => (
-              <div key={i} className="h-7 rounded bg-muted/50 animate-pulse" />
-            ))}
-          </div>
-          <div className="flex-1 flex items-center justify-center">
-            <div className="w-16 h-16 rounded bg-muted/50 animate-pulse" />
+        <div className="rounded-lg border bg-card p-6">
+          <div className="max-w-2xl mx-auto space-y-4">
+            <div className="h-10 w-10 rounded bg-muted/50 animate-pulse" />
+            <div className="h-10 w-2/3 rounded bg-muted/50 animate-pulse" />
+            <div className="h-24 rounded bg-muted/50 animate-pulse" />
           </div>
         </div>
       </RepoLayout>
@@ -152,219 +139,108 @@ export function NewJournalPage() {
 
   return (
     <RepoLayout owner={owner!} repo={repo!}>
-      <div className="flex h-[calc(100vh-200px)] -mx-6 -mt-6">
-        {/* Sidebar */}
-        <div className="w-64 border-r bg-muted/30 flex flex-col overflow-y-auto">
-          <div className="p-2 flex-1">
-            <div className="space-y-0.5">
-              {(tree || []).map((item) => (
-                <SidebarItem
-                  key={item.id}
-                  item={item}
-                  owner={owner!}
-                  repo={repo!}
-                  level={0}
-                />
-              ))}
-              {/* New page indicator */}
-              <div
-                className="flex items-center gap-1 py-1 px-1 rounded-md bg-primary/10"
-                style={{ paddingLeft: '4px' }}
-              >
-                <span className="w-5" />
-                <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-sm">
-                  {icon || <FileText className="h-4 w-4 text-primary" />}
-                </span>
-                <span className="flex-1 truncate text-sm text-primary font-medium">
-                  {title || 'Untitled'}
-                </span>
-              </div>
-            </div>
+      <div className="rounded-lg border bg-card">
+        {/* Header bar with actions */}
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <FileText className="h-4 w-4" />
+            <span>New page</span>
+            {parentId && <span className="text-muted-foreground/60">/ subpage</span>}
+          </div>
+          <div className="flex items-center gap-2">
+            <Link to={`/${owner}/${repo}/journal`}>
+              <Button variant="ghost" size="sm">
+                Cancel
+              </Button>
+            </Link>
+            <Button size="sm" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? 'Creating...' : 'Create page'}
+            </Button>
           </div>
         </div>
 
-        {/* Main content */}
-        <div className="flex-1 flex flex-col bg-background overflow-y-auto">
-          {/* Cover area (hover to show add cover button) */}
-          <div
-            className="h-12 group relative"
-            onMouseEnter={() => setIsHeaderHovered(true)}
-            onMouseLeave={() => setIsHeaderHovered(false)}
-          >
-            {isHeaderHovered && (
-              <div className="absolute top-4 left-16 flex items-center gap-2 text-sm text-muted-foreground">
-                <button className="flex items-center gap-1.5 px-2 py-1 rounded hover:bg-muted transition-colors">
-                  <ImagePlus className="h-4 w-4" />
-                  Add cover
+        {/* Content area */}
+        <div className="max-w-2xl mx-auto px-6 py-6">
+          {/* Icon */}
+          <div className="relative mb-4">
+            {icon ? (
+              <div className="relative inline-block group">
+                <span
+                  className="text-5xl cursor-pointer"
+                  onClick={() => setShowIconPicker(true)}
+                >
+                  {icon}
+                </span>
+                <div className="absolute -top-1 -right-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <button
+                    onClick={() => setIcon('')}
+                    className="p-1 bg-background border rounded shadow-sm hover:bg-muted"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowIconPicker(true)}
+                className="flex items-center gap-1.5 px-2 py-1 text-sm text-muted-foreground rounded hover:bg-muted transition-colors"
+              >
+                <Smile className="h-4 w-4" />
+                Add icon
+              </button>
+            )}
+
+            {/* Icon picker */}
+            {showIconPicker && (
+              <div className="absolute top-full left-0 z-50 mt-2 p-3 bg-popover border rounded-lg shadow-lg w-72">
+                <div className="grid grid-cols-6 gap-1">
+                  {COMMON_ICONS.map((emoji) => (
+                    <button
+                      key={emoji}
+                      onClick={() => handleIconChange(emoji)}
+                      className="p-2 text-2xl hover:bg-muted rounded transition-colors"
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={() => setShowIconPicker(false)}
+                  className="w-full mt-2 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  Close
                 </button>
               </div>
             )}
           </div>
 
-          {/* Content area */}
-          <div className="max-w-3xl mx-auto px-16 pb-24 flex-1">
-            {/* Icon */}
-            <div className="relative mb-4">
-              {icon ? (
-                <div className="relative inline-block group">
-                  <span
-                    className="text-7xl cursor-pointer"
-                    onClick={() => setShowIconPicker(true)}
-                  >
-                    {icon}
-                  </span>
-                  <div className="absolute -top-1 -right-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <button
-                      onClick={() => setIcon('')}
-                      className="p-1 bg-background border rounded shadow-sm hover:bg-muted"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <button
-                  onClick={() => setShowIconPicker(true)}
-                  className="flex items-center gap-1.5 px-2 py-1 text-sm text-muted-foreground rounded hover:bg-muted transition-colors"
-                >
-                  <Smile className="h-4 w-4" />
-                  Add icon
-                </button>
-              )}
+          {/* Title */}
+          <textarea
+            ref={titleRef}
+            value={title}
+            onChange={handleTitleChange}
+            placeholder="Page title"
+            className="w-full text-3xl font-bold bg-transparent border-0 outline-none resize-none placeholder:text-muted-foreground/50 mb-4"
+            rows={1}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+              }
+            }}
+          />
 
-              {/* Icon picker */}
-              {showIconPicker && (
-                <div className="absolute top-full left-0 z-50 mt-2 p-3 bg-popover border rounded-lg shadow-lg w-72">
-                  <div className="grid grid-cols-6 gap-1">
-                    {COMMON_ICONS.map((emoji) => (
-                      <button
-                        key={emoji}
-                        onClick={() => handleIconChange(emoji)}
-                        className="p-2 text-2xl hover:bg-muted rounded transition-colors"
-                      >
-                        {emoji}
-                      </button>
-                    ))}
-                  </div>
-                  <button
-                    onClick={() => setShowIconPicker(false)}
-                    className="w-full mt-2 text-sm text-muted-foreground hover:text-foreground"
-                  >
-                    Close
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Title */}
-            <textarea
-              ref={titleRef}
-              value={title}
-              onChange={handleTitleChange}
-              placeholder="Untitled"
-              className="w-full text-4xl font-bold bg-transparent border-0 outline-none resize-none placeholder:text-muted-foreground/50 mb-4"
-              rows={1}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault();
-                  // Focus will move to block editor naturally
-                }
-              }}
-            />
-
-            {/* Content - Block Editor */}
+          {/* Content - Block Editor */}
+          <div className="min-h-[200px]">
             <BlockEditor
               value={content}
               onChange={handleContentChange}
-              placeholder="Type '/' for commands..."
+              placeholder="Start writing or type '/' for commands..."
               autoFocus={false}
             />
-
-            {/* Save bar */}
-            <div className="fixed bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-3 px-4 py-2 bg-background border rounded-lg shadow-lg">
-              <Link to={`/${owner}/${repo}/journal`}>
-                <Button variant="ghost" size="sm">
-                  Cancel
-                </Button>
-              </Link>
-              <Button size="sm" onClick={handleSave} disabled={isSaving}>
-                {isSaving ? 'Creating...' : 'Create page'}
-              </Button>
-            </div>
           </div>
         </div>
       </div>
     </RepoLayout>
-  );
-}
-
-// Sidebar item (simplified version)
-interface SidebarItemProps {
-  item: {
-    id: string;
-    title: string;
-    slug: string;
-    status: string;
-    icon?: string | null;
-    children: any[];
-  };
-  owner: string;
-  repo: string;
-  level: number;
-}
-
-function SidebarItem({ item, owner, repo, level }: SidebarItemProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const hasChildren = item.children && item.children.length > 0;
-
-  return (
-    <div>
-      <div
-        className="flex items-center gap-1 py-1 px-1 rounded-md hover:bg-muted/70 transition-colors"
-        style={{ paddingLeft: `${level * 12 + 4}px` }}
-      >
-        {hasChildren ? (
-          <button
-            onClick={() => setIsOpen(!isOpen)}
-            className="h-5 w-5 flex items-center justify-center rounded hover:bg-muted-foreground/20"
-          >
-            <ChevronRight
-              className={cn(
-                'h-3.5 w-3.5 text-muted-foreground transition-transform',
-                isOpen && 'rotate-90'
-              )}
-            />
-          </button>
-        ) : (
-          <span className="w-5" />
-        )}
-
-        <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-sm">
-          {item.icon || <FileText className="h-4 w-4 text-muted-foreground" />}
-        </span>
-
-        <Link
-          to={`/${owner}/${repo}/journal/${item.slug}`}
-          className="flex-1 truncate text-sm text-foreground/80 py-0.5"
-        >
-          {item.title || 'Untitled'}
-        </Link>
-      </div>
-
-      {hasChildren && isOpen && (
-        <div>
-          {item.children.map((child: any) => (
-            <SidebarItem
-              key={child.id}
-              item={child}
-              owner={owner}
-              repo={repo}
-              level={level + 1}
-            />
-          ))}
-        </div>
-      )}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix double scrolling caused by fixed viewport heights (`h-[calc(100vh-200px)]`)
- Move "Create page" actions to header bar so they're visible above the fold
- Fix overlapping placeholder text in the BlockEditor component
- Simplify layouts using card-based containers with proper min-heights

## Changes

### Journal Index (`index.tsx`)
- Replace fixed height with `min-h-[500px]` card layout
- Combine search and new page button in header row
- Remove negative margins that caused layout issues

### New Page (`page-new.tsx`)
- Remove redundant sidebar (page tree)
- Add header bar with Cancel/Create buttons (visible immediately)
- Simplify form layout with centered content

### Page Detail (`page-detail.tsx`)
- Use card-based layout with narrower sidebar (256px -> 224px)
- Remove unused `isHeaderHovered` state
- Fix "Saving..." indicator positioning

### BlockEditor
- Remove duplicate placeholder that was causing overlapping text
- Pass placeholder prop to BlockItem for first block only