### PR TITLE
fix: user assignment to PRs and Issues not working

### DIFF
--- a/src/api/trpc/routers/issues.ts
+++ b/src/api/trpc/routers/issues.ts
@@ -36,8 +36,8 @@ export const issuesRouter = router({
         state: z.enum(['open', 'closed']).optional(),
         status: issueStatusSchema.optional(),
         priority: issuePrioritySchema.optional(),
-        authorId: z.string().uuid().optional(),
-        assigneeId: z.string().uuid().optional(),
+        authorId: z.string().optional(), // User IDs are text, not UUIDs
+        assigneeId: z.string().optional(), // User IDs are text, not UUIDs
         projectId: z.string().uuid().optional(),
         cycleId: z.string().uuid().optional(),
         limit: z.number().min(1).max(100).default(20),
@@ -169,7 +169,7 @@ export const issuesRouter = router({
         title: z.string().min(1, 'Title is required').max(256),
         body: z.string().optional(),
         labelIds: z.array(z.string().uuid()).optional(),
-        assigneeId: z.string().uuid().optional(),
+        assigneeId: z.string().optional(), // User IDs are text, not UUIDs
         priority: issuePrioritySchema.optional(),
         status: issueStatusSchema.optional(),
         dueDate: z.string().datetime().optional(),
@@ -392,7 +392,7 @@ export const issuesRouter = router({
     .input(
       z.object({
         issueId: z.string().uuid(),
-        assigneeId: z.string().uuid(),
+        assigneeId: z.string(), // User IDs are text, not UUIDs
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -693,7 +693,7 @@ export const issuesRouter = router({
   listByAssignee: publicProcedure
     .input(
       z.object({
-        assigneeId: z.string().uuid(),
+        assigneeId: z.string(), // User IDs are text, not UUIDs
         state: z.enum(['open', 'closed']).optional(),
       })
     )
@@ -847,8 +847,8 @@ export const issuesRouter = router({
       z.object({
         repoId: z.string().uuid(),
         state: z.enum(['open', 'closed']).optional(),
-        authorId: z.string().uuid().optional(),
-        assigneeId: z.string().uuid().optional(),
+        authorId: z.string().optional(), // User IDs are text, not UUIDs
+        assigneeId: z.string().optional(), // User IDs are text, not UUIDs
         projectId: z.string().uuid().optional(),
         cycleId: z.string().uuid().optional(),
       })
@@ -1275,7 +1275,7 @@ export const issuesRouter = router({
         repoId: z.string().uuid(),
         state: z.enum(['open', 'closed']).optional(),
         status: issueStatusSchema.optional(),
-        assigneeId: z.string().uuid().optional(),
+        assigneeId: z.string().optional(), // User IDs are text, not UUIDs
         projectId: z.string().uuid().optional(),
         cycleId: z.string().uuid().optional(),
       })
@@ -1451,7 +1451,7 @@ export const issuesRouter = router({
         title: z.string().min(1, 'Title is required').max(256),
         body: z.string().optional(),
         priority: issuePrioritySchema.optional(),
-        assigneeId: z.string().uuid().optional(),
+        assigneeId: z.string().optional(), // User IDs are text, not UUIDs
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -2029,7 +2029,7 @@ export const issuesRouter = router({
     .input(
       z.object({
         repoId: z.string().uuid(),
-        userId: z.string().uuid(),
+        userId: z.string(), // User IDs are text, not UUIDs
       })
     )
     .query(async ({ input }) => {

--- a/src/api/trpc/routers/projects.ts
+++ b/src/api/trpc/routers/projects.ts
@@ -270,7 +270,7 @@ export const projectsRouter = router({
     .input(
       z.object({
         projectId: z.string().uuid(),
-        userId: z.string().uuid(),
+        userId: z.string(), // User IDs are text, not UUIDs
         role: z.string().default('member'),
       })
     )
@@ -305,7 +305,7 @@ export const projectsRouter = router({
     .input(
       z.object({
         projectId: z.string().uuid(),
-        userId: z.string().uuid(),
+        userId: z.string(), // User IDs are text, not UUIDs
       })
     )
     .mutation(async ({ input, ctx }) => {

--- a/src/server/routes/issues.ts
+++ b/src/server/routes/issues.ts
@@ -158,6 +158,16 @@ export function createIssueRoutes(): Hono {
       await issueModel.reopen(issue.id);
     }
 
+    // Handle assignee changes
+    if (body.assignee !== undefined || body.assigneeId !== undefined) {
+      const assigneeId = body.assigneeId ?? body.assignee;
+      if (assigneeId) {
+        await issueModel.assign(issue.id, assigneeId);
+      } else {
+        await issueModel.unassign(issue.id);
+      }
+    }
+
     // Handle other updates
     const updates: Parameters<typeof issueModel.update>[1] = {};
     if (body.title !== undefined) updates.title = body.title;


### PR DESCRIPTION
## Summary

- Fixes user assignment functionality for both Issues and PRs that was completely broken
- Root cause: Zod validation incorrectly expected UUIDs for user IDs, but better-auth uses text IDs

## Changes

### REST API (`src/server/routes/issues.ts`)
- Added handling for `assignee` and `assigneeId` fields in the PATCH endpoint
- Calls `issueModel.assign()` or `issueModel.unassign()` appropriately

### tRPC Issues Router (`src/api/trpc/routers/issues.ts`)
Fixed Zod validation for user ID fields (changed from `.uuid()` to `.string()`):
- `assign` procedure - `assigneeId`
- `listByAssignee` procedure - `assigneeId`
- `list` procedure - `authorId`, `assigneeId`
- `create` procedure - `assigneeId`
- `listForBoard` procedure - `authorId`, `assigneeId`
- `getTotalEstimate` procedure - `assigneeId`
- `createSubIssue` procedure - `assigneeId`
- `listViews` procedure - `userId`

### tRPC Projects Router (`src/api/trpc/routers/projects.ts`)
Fixed Zod validation for user ID fields:
- `addMember` procedure - `userId`
- `removeMember` procedure - `userId`

## Testing
- Verified the schema: `src/db/auth-schema.ts` shows user IDs are `text("id")`, not UUIDs
- PR reviewer assignment was already correct (using `z.string()` without `.uuid()`)