### PR TITLE
fix(web): prevent kanban board columns from stretching to full height

### DIFF
--- a/apps/web/src/components/issue/kanban-board.tsx
+++ b/apps/web/src/components/issue/kanban-board.tsx
@@ -240,7 +240,7 @@ export function KanbanBoard({
             <div
               key={status}
               className={cn(
-                'flex-shrink-0 w-72 flex flex-col rounded-lg border bg-card',
+                'flex-shrink-0 w-72 flex flex-col rounded-lg border bg-card h-fit',
                 isDropTarget && 'ring-2 ring-primary ring-offset-2'
               )}
               onDragOver={(e) => handleDragOver(e, status)}


### PR DESCRIPTION
## Summary
- Adds `h-fit` to kanban board column containers to prevent them from stretching to fill available vertical space
- Columns now properly size to their content instead of extending all the way down the page