### PR TITLE
feat(search): add file name and code content search with glob patterns

### DIFF
--- a/src/ai/tools/search.ts
+++ b/src/ai/tools/search.ts
@@ -10,14 +10,15 @@ import { SearchEngine } from '../../ui/search.js';
 
 export const searchTool = createTool({
   id: 'wit-search',
-  description: 'Search the repository for commits, files, and content matching a query. Use this to find specific code, commits by message, or files by name.',
+  description: 'Search the repository for commits, files, and content matching a query. Use this to find specific code, commits by message, or files by name. Supports glob patterns for file filtering.',
   inputSchema: z.object({
-    query: z.string().describe('Search query string'),
+    query: z.string().describe('Search query string (text pattern or regex)'),
     searchCommits: z.boolean().optional().default(true).describe('Search in commit messages'),
     searchFiles: z.boolean().optional().default(true).describe('Search in file names'),
     searchContent: z.boolean().optional().default(true).describe('Search in file contents'),
     caseSensitive: z.boolean().optional().default(false),
     maxResults: z.number().optional().default(20),
+    filePattern: z.string().optional().describe('Glob pattern to filter files (e.g., "*.ts", "src/**/*.js")'),
   }),
   outputSchema: z.object({
     commits: z.array(z.object({
@@ -40,7 +41,7 @@ export const searchTool = createTool({
     totalResults: z.number(),
     searchTime: z.number(),
   }),
-  execute: async ({ query, searchCommits, searchFiles, searchContent, caseSensitive, maxResults }) => {
+  execute: async ({ query, searchCommits, searchFiles, searchContent, caseSensitive, maxResults, filePattern }) => {
     try {
       const repo = Repository.find();
       const searchEngine = new SearchEngine(repo);
@@ -51,6 +52,7 @@ export const searchTool = createTool({
         searchContent,
         caseSensitive,
         maxResults,
+        filePattern,
       });
       
       return {
@@ -80,6 +82,115 @@ export const searchTool = createTool({
         files: [],
         content: [],
         totalResults: 0,
+        searchTime: 0,
+      };
+    }
+  },
+});
+
+/**
+ * Glob Search Tool
+ * Find files by glob pattern only (no text query required)
+ */
+export const globSearchTool = createTool({
+  id: 'wit-glob-search',
+  description: 'Find files matching a glob pattern. Use this to locate files by name pattern without searching content. Examples: "*.ts" for TypeScript files, "src/**/*.test.js" for test files in src.',
+  inputSchema: z.object({
+    pattern: z.string().describe('Glob pattern to match files (e.g., "*.ts", "**/*.test.js", "src/**/*.tsx")'),
+    maxResults: z.number().optional().default(50).describe('Maximum number of results to return'),
+  }),
+  outputSchema: z.object({
+    files: z.array(z.object({
+      path: z.string(),
+      filename: z.string(),
+    })),
+    totalFiles: z.number(),
+    searchTime: z.number(),
+  }),
+  execute: async ({ pattern, maxResults }) => {
+    try {
+      const repo = Repository.find();
+      const searchEngine = new SearchEngine(repo);
+      const startTime = Date.now();
+      
+      const results = searchEngine.searchFilesByGlob(pattern, { maxResults });
+      
+      return {
+        files: results.map(f => ({
+          path: f.path,
+          filename: f.filename,
+        })),
+        totalFiles: results.length,
+        searchTime: Date.now() - startTime,
+      };
+    } catch (error) {
+      return {
+        files: [],
+        totalFiles: 0,
+        searchTime: 0,
+      };
+    }
+  },
+});
+
+/**
+ * Content Search Tool
+ * Search for code patterns within specific files
+ */
+export const contentSearchTool = createTool({
+  id: 'wit-content-search',
+  description: 'Search for text/code patterns within files. Optionally filter by file type using glob patterns. Returns matching lines with context.',
+  inputSchema: z.object({
+    query: z.string().describe('Text or regex pattern to search for in file contents'),
+    filePattern: z.string().optional().describe('Glob pattern to filter which files to search (e.g., "*.ts", "src/**/*.js")'),
+    caseSensitive: z.boolean().optional().default(false),
+    contextLines: z.number().optional().default(2).describe('Number of context lines before and after match'),
+    maxResults: z.number().optional().default(30),
+  }),
+  outputSchema: z.object({
+    matches: z.array(z.object({
+      path: z.string(),
+      lineNumber: z.number(),
+      lineContent: z.string(),
+      matchedText: z.string(),
+      contextBefore: z.array(z.string()),
+      contextAfter: z.array(z.string()),
+    })),
+    totalMatches: z.number(),
+    searchTime: z.number(),
+  }),
+  execute: async ({ query, filePattern, caseSensitive, contextLines, maxResults }) => {
+    try {
+      const repo = Repository.find();
+      const searchEngine = new SearchEngine(repo);
+      const startTime = Date.now();
+      
+      const results = searchEngine.search(query, {
+        searchCommits: false,
+        searchFiles: false,
+        searchContent: true,
+        caseSensitive,
+        contextLines,
+        maxResults,
+        filePattern,
+      });
+      
+      return {
+        matches: results.content.map(c => ({
+          path: c.path,
+          lineNumber: c.lineNumber,
+          lineContent: c.lineContent,
+          matchedText: c.matchedText,
+          contextBefore: c.context.before,
+          contextAfter: c.context.after,
+        })),
+        totalMatches: results.content.length,
+        searchTime: Date.now() - startTime,
+      };
+    } catch (error) {
+      return {
+        matches: [],
+        totalMatches: 0,
         searchTime: 0,
       };
     }


### PR DESCRIPTION
## Summary

- Add glob pattern support for file name searching (e.g., `*.ts`, `src/**/*.js`)
- Add file filtering for content searches to target specific file types
- Add new CLI flags for targeted searches (`--files`, `--content`, `--in`)

## Changes

### SearchEngine (`src/ui/search.ts`)
- Added `filePattern` option for glob-based file filtering
- Added `searchFilesByGlob()` method for finding files by pattern only
- Added `searchContentInFiles()` method for combined file + content search
- Added glob pattern support with `*`, `**`, `?` wildcards
- Added `getAllFiles()` and `walkWorkingDir()` for comprehensive file discovery

### CLI (`src/commands/search.ts`)
- `wit search files "*.ts"` - Find files by glob pattern
- `wit search "pattern" --in "*.ts"` - Search content in specific file types
- `wit search --files "pattern"` - Search file names only
- `wit search --content "pattern"` - Search file contents only

### AI Tools (`src/ai/tools/search.ts`)
- Added `filePattern` option to existing `searchTool`
- Added `globSearchTool` for file pattern matching
- Added `contentSearchTool` for targeted content search with file filtering

## Usage Examples

```bash
# Find all TypeScript files
wit search files "*.ts"

# Search for "handleAuth" only in TypeScript files
wit search "handleAuth" --in "*.ts"

# Search file names for "test"
wit search --files "test"

# Search file contents for "TODO" in src directory
wit search "TODO" --in "src/**/*.ts"
```