### PR TITLE
fix: show commit changes in commit detail page

### DIFF
--- a/apps/web/src/components/diff/diff-viewer.tsx
+++ b/apps/web/src/components/diff/diff-viewer.tsx
@@ -88,13 +88,13 @@ function parseDiff(diffText: string): DiffFile[] {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // New file diff header: diff --git a/path b/path
-    if (line.startsWith('diff --git')) {
+    // New file diff header: diff --git a/path b/path or diff --wit a/path b/path
+    if (line.startsWith('diff --git') || line.startsWith('diff --wit')) {
       if (currentFile) {
         if (currentHunk) currentFile.hunks.push(currentHunk);
         files.push(currentFile);
       }
-      const match = line.match(/diff --git a\/(.*) b\/(.*)/);
+      const match = line.match(/diff --(?:git|wit) a\/(.*) b\/(.*)/);
       currentFile = {
         path: match ? match[2] : 'unknown',
         oldPath: match ? match[1] : undefined,


### PR DESCRIPTION
## Summary
- Fixed the commit detail page to properly display what was added/changed in a commit
- The diff was not being generated correctly due to incorrect API call to `formatUnifiedDiff`

## Changes
- **Backend (`src/api/trpc/routers/repos.ts`)**:
  - Fixed diff generation to properly use `createHunks()` and build `FileDiff` objects
  - Changed condition from `diffLines.length > 0` to `hunks.length > 0` to only include files with actual changes
  - Added error logging for diff computation failures (was silently catching errors)

- **Frontend (`apps/web/src/components/diff/diff-viewer.tsx`)**:
  - Added support for parsing `diff --wit` format in addition to `diff --git`

## Testing
Verified that the diff generation produces correct unified diff output for:
- New files (initial commits)
- Modified files
- Deleted files