### PR TITLE
fix: starred and watched state not persisting

### DIFF
--- a/apps/web/src/routes/repo/components/repo-layout.tsx
+++ b/apps/web/src/routes/repo/components/repo-layout.tsx
@@ -89,7 +89,7 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     onMutate: async () => {
       await utils.repos.isStarred.cancel({ repoId: repoData?.repo.id || '' });
       const previousStarred = utils.repos.isStarred.getData({ repoId: repoData?.repo.id || '' });
-      utils.repos.isStarred.setData({ repoId: repoData?.repo.id || '' }, true);
+      utils.repos.isStarred.setData({ repoId: repoData?.repo.id || '' }, { starred: true });
       return { previousStarred };
     },
     onSuccess: () => {
@@ -111,7 +111,7 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     onMutate: async () => {
       await utils.repos.isStarred.cancel({ repoId: repoData?.repo.id || '' });
       const previousStarred = utils.repos.isStarred.getData({ repoId: repoData?.repo.id || '' });
-      utils.repos.isStarred.setData({ repoId: repoData?.repo.id || '' }, false);
+      utils.repos.isStarred.setData({ repoId: repoData?.repo.id || '' }, { starred: false });
       return { previousStarred };
     },
     onSuccess: () => {
@@ -134,7 +134,7 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     onMutate: async () => {
       await utils.repos.isWatching.cancel({ repoId: repoData?.repo.id || '' });
       const previousWatching = utils.repos.isWatching.getData({ repoId: repoData?.repo.id || '' });
-      utils.repos.isWatching.setData({ repoId: repoData?.repo.id || '' }, true);
+      utils.repos.isWatching.setData({ repoId: repoData?.repo.id || '' }, { watching: true });
       return { previousWatching };
     },
     onSuccess: () => {
@@ -156,7 +156,7 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     onMutate: async () => {
       await utils.repos.isWatching.cancel({ repoId: repoData?.repo.id || '' });
       const previousWatching = utils.repos.isWatching.getData({ repoId: repoData?.repo.id || '' });
-      utils.repos.isWatching.setData({ repoId: repoData?.repo.id || '' }, false);
+      utils.repos.isWatching.setData({ repoId: repoData?.repo.id || '' }, { watching: false });
       return { previousWatching };
     },
     onSuccess: () => {
@@ -186,8 +186,8 @@ export function RepoLayout({ owner, repo, children }: RepoLayoutProps) {
     },
   });
 
-  const isStarred = starredData || false;
-  const isWatching = watchingData || false;
+  const isStarred = starredData?.starred || false;
+  const isWatching = watchingData?.watching || false;
 
   const handleStar = () => {
     if (!repoData?.repo.id) return;


### PR DESCRIPTION
## Summary

- Fixed starred/watched buttons not persisting their state after clicking
- The API returns `{ starred: boolean }` and `{ watching: boolean }` objects, but the UI was treating responses as direct booleans
- Updated state derivation to access `.starred` and `.watching` properties correctly
- Fixed optimistic updates to use the correct object format

## Changes

**File:** `apps/web/src/routes/repo/components/repo-layout.tsx`

1. Fixed state derivation:
   ```typescript
   // Before
   const isStarred = starredData || false;
   const isWatching = watchingData || false;
   
   // After  
   const isStarred = starredData?.starred || false;
   const isWatching = watchingData?.watching || false;
   ```

2. Fixed optimistic updates to use `{ starred: true/false }` and `{ watching: true/false }` instead of raw booleans