### PR TITLE
docs: documentation audit and README refresh with wit.sh links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Git that understands your code.** A Git implementation with AI woven into the workflow.
 
+[Website](https://wit.sh) | [Documentation](https://docs.wit.sh) | [Quickstart](https://docs.wit.sh/quickstart)
+
 ## Why wit?
 
 - **Undo anything** - `wit undo` instead of deciphering the reflog
@@ -39,11 +41,11 @@ This is early software. We're shipping fast, not perfect. Check the [ROADMAP](./
 
 ## Documentation
 
-- **[Getting Started](./docs/getting-started.mdx)** - From zero to productive in 5 minutes
-- **[Why wit?](./docs/why-wit.mdx)** - The problems we're solving
-- **[Commands Reference](./docs/commands/reference.mdx)** - Every command documented
-- **[AI Features](./docs/features/ai-powered.mdx)** - Commit messages, review, semantic search
-- **[Full Docs](./docs/)** - Everything else
+- **[Quickstart](https://docs.wit.sh/quickstart)** - From zero to productive in 5 minutes
+- **[Why wit?](https://docs.wit.sh/why-wit)** - The problems we're solving
+- **[Commands](https://docs.wit.sh/commands/overview)** - Every command documented
+- **[AI Features](https://docs.wit.sh/features/ai-powered)** - Commit messages, review, semantic search
+- **[Full Docs](https://docs.wit.sh)** - Everything else
 
 ## Quick Reference
 
@@ -68,6 +70,10 @@ wit cleanup              # delete merged branches
 ## Requirements
 
 Node.js >= 22.13.0
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/docs/commands/advanced.mdx
+++ b/docs/commands/advanced.mdx
@@ -6,7 +6,7 @@ description: "Power user commands for advanced workflows"
 These commands provide powerful capabilities for advanced workflows.
 
 <Note>
-For stacked diffs, see [Stacked Diffs](/commands/stacked-diffs).
+For stacked diffs, see [Stacked Diffs](/features/stacked-diffs).
 For history rewriting (cherry-pick, rebase, revert), see [History Rewriting](/commands/history-rewriting).
 For remote operations, see [Remotes](/commands/remotes).
 For stash, see [Stash](/commands/stash).

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -333,8 +333,7 @@ describe('git compatibility', () => {
 ```
 docs/
 ├── introduction.mdx        # Overview
-├── quickstart.mdx          # Getting started
-├── installation.mdx        # Install guide
+├── quickstart.mdx          # Getting started & install guide
 ├── commands/               # Command reference
 ├── features/               # Feature deep-dives
 ├── architecture/           # Internals

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -17,6 +17,10 @@
   },
   "topbarLinks": [
     {
+      "name": "Website",
+      "url": "https://wit.sh"
+    },
+    {
       "name": "GitHub",
       "url": "https://github.com/abhiaiyer91/wit"
     }
@@ -41,14 +45,14 @@
   ],
   "anchors": [
     {
+      "name": "Website",
+      "icon": "globe",
+      "url": "https://wit.sh"
+    },
+    {
       "name": "GitHub",
       "icon": "github",
       "url": "https://github.com/abhiaiyer91/wit"
-    },
-    {
-      "name": "Community",
-      "icon": "discord",
-      "url": "https://discord.gg/wit"
     },
     {
       "name": "Roadmap",
@@ -208,7 +212,7 @@
     }
   ],
   "footerSocials": {
-    "github": "https://github.com/abhiaiyer91/wit",
-    "discord": "https://discord.gg/wit"
+    "website": "https://wit.sh",
+    "github": "https://github.com/abhiaiyer91/wit"
   }
 }


### PR DESCRIPTION
## Summary

- Add prominent links to wit.sh and docs.wit.sh in README header
- Update all documentation links to point to live docs site instead of local paths
- Fix broken internal links in docs
- Clean up inactive Discord references

## Changes

### README.md
- Added `[Website](https://wit.sh) | [Documentation](https://docs.wit.sh) | [Quickstart](https://docs.wit.sh/quickstart)` header
- Updated Documentation section to use `docs.wit.sh` URLs
- Added Contributing section

### docs/mint.json
- Added "Website" topbar link to wit.sh
- Added "Website" anchor with globe icon
- Removed inactive Discord community link
- Updated footer socials

### docs/commands/advanced.mdx
- Fixed broken link: `/commands/stacked-diffs` → `/features/stacked-diffs`

### docs/contributing.mdx
- Removed reference to non-existent `installation.mdx` from docs structure example