### PR TITLE
fix: add /api proxy to vite dev server config

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         target: 'http://localhost:3000',
         changeOrigin: true,
       },
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- Adds `/api` to the Vite dev server proxy configuration
- Fixes the stream endpoint (`/api/agent/chat/stream`) returning HTML instead of proxying to the backend

The issue was that only `/trpc` routes were being proxied to the backend server, so requests to `/api/*` were being handled by Vite and served the frontend HTML.