### PR TITLE
feat: add leaderboard page showing most active repos

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -69,6 +69,7 @@ import { TeamDetailPage } from './routes/org/team-detail';
 import { SearchPage } from './routes/search';
 import { InboxPage } from './routes/inbox';
 import { WrappedPage } from './routes/wrapped';
+import { LeaderboardPage } from './routes/leaderboard';
 
 // Scroll to top on route change
 function ScrollToTop() {
@@ -113,6 +114,7 @@ export function App() {
             <Route path="/orgs/new" element={<NewOrgPage />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/inbox" element={<InboxPage />} />
+            <Route path="/leaderboard" element={<LeaderboardPage />} />
 
             {/* Organization routes */}
             <Route path="/org/:slug" element={<OrgPage />} />

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -14,6 +14,7 @@ import {
   X,
   Building2,
   Flame,
+  Trophy,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -64,6 +65,15 @@ export function Header() {
                 <GitBranch className="h-4 w-4 md:h-5 md:w-5 text-primary" />
               </div>
               <span className="font-bold text-lg md:text-xl tracking-tight">wit</span>
+            </Link>
+
+            {/* Leaderboard link */}
+            <Link
+              to="/leaderboard"
+              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-lg transition-all"
+            >
+              <Trophy className="h-4 w-4" />
+              <span>Leaderboard</span>
             </Link>
           </div>
 
@@ -219,6 +229,15 @@ export function Header() {
 
             {/* Mobile navigation links */}
             <nav className="space-y-1">
+              {/* Leaderboard - visible to all */}
+              <Link
+                to="/leaderboard"
+                className="flex items-center gap-3 px-3 py-2.5 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/40 rounded-lg transition-all"
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <Trophy className="h-4 w-4" />
+                Leaderboard
+              </Link>
               {authenticated && (
                 <>
                   <Link

--- a/apps/web/src/routes/leaderboard.tsx
+++ b/apps/web/src/routes/leaderboard.tsx
@@ -1,0 +1,140 @@
+import { Link } from 'react-router-dom';
+import { Trophy, GitCommit, Star, BookOpen, Building2 } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpc } from '@/lib/trpc';
+
+function LeaderboardSkeleton() {
+  return (
+    <div className="container max-w-[900px] mx-auto py-8 space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-5 w-96" />
+      </div>
+      <div className="space-y-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-24 rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getRankBadge(rank: number) {
+  if (rank === 1) {
+    return (
+      <div className="flex items-center justify-center w-10 h-10 rounded-full bg-yellow-500/20">
+        <Trophy className="h-5 w-5 text-yellow-500" />
+      </div>
+    );
+  }
+  if (rank === 2) {
+    return (
+      <div className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-400/20">
+        <Trophy className="h-5 w-5 text-gray-400" />
+      </div>
+    );
+  }
+  if (rank === 3) {
+    return (
+      <div className="flex items-center justify-center w-10 h-10 rounded-full bg-amber-600/20">
+        <Trophy className="h-5 w-5 text-amber-600" />
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center justify-center w-10 h-10 rounded-full bg-muted">
+      <span className="text-sm font-medium text-muted-foreground">{rank}</span>
+    </div>
+  );
+}
+
+export function LeaderboardPage() {
+  const { data: leaderboard, isLoading } = trpc.repos.leaderboard.useQuery({ limit: 20 });
+
+  if (isLoading) {
+    return <LeaderboardSkeleton />;
+  }
+
+  return (
+    <div className="container max-w-[900px] mx-auto py-8 space-y-6">
+      {/* Header */}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold flex items-center gap-3">
+          <Trophy className="h-8 w-8 text-yellow-500" />
+          Leaderboard
+        </h1>
+        <p className="text-muted-foreground">
+          Most active repositories by commits in the last 7 days
+        </p>
+      </div>
+
+      {/* Leaderboard List */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <GitCommit className="h-5 w-5" />
+            Top Repositories
+          </CardTitle>
+          <CardDescription>
+            Ranked by number of commits in the past week
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {!leaderboard || leaderboard.length === 0 ? (
+            <div className="text-center py-12">
+              <BookOpen className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium mb-2">No activity yet</h3>
+              <p className="text-muted-foreground">
+                No repositories have commits in the last 7 days.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {leaderboard.map((repo, index) => (
+                <Link
+                  key={repo.id}
+                  to={`/${repo.ownerName}/${repo.name}`}
+                  className="flex items-center gap-4 p-4 rounded-lg border border-border hover:bg-muted/50 transition-colors"
+                >
+                  {/* Rank */}
+                  {getRankBadge(index + 1)}
+
+                  {/* Repo Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      {repo.ownerType === 'organization' && (
+                        <Building2 className="h-4 w-4 text-muted-foreground" />
+                      )}
+                      <span className="font-medium text-primary hover:underline">
+                        {repo.ownerName}/{repo.name}
+                      </span>
+                    </div>
+                    {repo.description && (
+                      <p className="text-sm text-muted-foreground truncate mt-1">
+                        {repo.description}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Stats */}
+                  <div className="flex items-center gap-4 text-sm">
+                    <div className="flex items-center gap-1 text-muted-foreground">
+                      <Star className="h-4 w-4" />
+                      <span>{repo.starsCount}</span>
+                    </div>
+                    <Badge variant="secondary" className="font-mono">
+                      <GitCommit className="h-3 w-3 mr-1" />
+                      {repo.commitCount} commits
+                    </Badge>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/db/models/repository.ts
+++ b/src/db/models/repository.ts
@@ -252,6 +252,18 @@ export const repoModel = {
   },
 
   /**
+   * List all public repositories
+   */
+  async listAllPublic(): Promise<Repository[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.isPrivate, false))
+      .orderBy(desc(repositories.pushedAt));
+  },
+
+  /**
    * List forked repositories
    */
   async listForks(repoId: string): Promise<Repository[]> {


### PR DESCRIPTION
## Summary

- Add a new leaderboard page that shows repositories ranked by commit count in the last 7 days
- Add leaderboard link to the header navigation for easy access

## Changes

### Backend
- Add `repos.leaderboard` API endpoint that fetches all public repos, counts commits from the last 7 days by walking git history, and returns sorted results
- Add `repoModel.listAllPublic()` method to fetch all public repositories

### Frontend
- Create `LeaderboardPage` component with:
  - Trophy icons for top 3 positions (gold, silver, bronze)
  - Repository cards showing owner/name, description, stars, and commit count
  - Empty state when no repos have recent commits
  - Loading skeleton
- Add `/leaderboard` route
- Add Leaderboard link to header navigation (both desktop and mobile)

## Screenshots

The leaderboard page displays:
- Rank badges (trophy icons for 1-3, numbers for 4+)
- Repository full path (owner/name)
- Description (if available)
- Star count
- Commit count in the last 7 days