### PR TITLE
Wrapped page loading issue

### DIFF
--- a/apps/web/src/routes/wrapped.tsx
+++ b/apps/web/src/routes/wrapped.tsx
@@ -359,7 +359,7 @@ export function WrappedPage() {
   const [selectedMonth, setSelectedMonth] = useState(now.getMonth() + 1);
   
   // Fetch user info for the username
-  const { data: profileUser, isLoading: userLoading } = trpc.users.getByUsername.useQuery(
+  const { data: profileUser, isLoading: userLoading } = trpc.users.get.useQuery(
     { username: username! },
     { enabled: !!username }
   );


### PR DESCRIPTION
Fix WrappedPage not loading due to incorrect tRPC procedure name.

The `WrappedPage` component was attempting to call `trpc.users.getByUsername.useQuery()`, but the `users` router only exposes a procedure named `get`. This mismatch prevented the page from loading correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-7486d313-ecca-4a0a-b8f9-e67d7fe3cfc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7486d313-ecca-4a0a-b8f9-e67d7fe3cfc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

