### PR TITLE
feat: add custom issue stages for workflow customization

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -867,6 +867,111 @@ export class ApiClient {
       const query = limit ? `?limit=${limit}` : '';
       return this.request('GET', `/api/repos/${owner}/${repo}/issues/activity${query}`);
     },
+
+    // =========================================================================
+    // Stage Operations (Custom Workflow)
+    // =========================================================================
+
+    /**
+     * Update issue stage (using custom workflow)
+     */
+    updateStage: async (
+      owner: string,
+      repo: string,
+      number: number,
+      stageKey: string
+    ): Promise<Issue> => {
+      return this.request('PATCH', `/api/repos/${owner}/${repo}/issues/${number}/stage`, {
+        stageKey,
+      });
+    },
+  };
+
+  // ============================================================================
+  // Stage Operations (Custom Workflow)
+  // ============================================================================
+
+  readonly stages = {
+    /**
+     * List all stages for a repository
+     */
+    list: async (owner: string, repo: string): Promise<IssueStage[]> => {
+      return this.request('GET', `/api/repos/${owner}/${repo}/stages`);
+    },
+
+    /**
+     * Get a specific stage
+     */
+    get: async (owner: string, repo: string, key: string): Promise<IssueStage> => {
+      return this.request('GET', `/api/repos/${owner}/${repo}/stages/${key}`);
+    },
+
+    /**
+     * Create a new stage
+     */
+    create: async (
+      owner: string,
+      repo: string,
+      data: {
+        key: string;
+        name: string;
+        description?: string;
+        icon?: string;
+        color?: string;
+        position?: number;
+        isClosedState?: boolean;
+        isTriageState?: boolean;
+        isDefault?: boolean;
+      }
+    ): Promise<IssueStage> => {
+      return this.request('POST', `/api/repos/${owner}/${repo}/stages`, data);
+    },
+
+    /**
+     * Update a stage
+     */
+    update: async (
+      owner: string,
+      repo: string,
+      key: string,
+      data: {
+        name?: string;
+        description?: string;
+        icon?: string;
+        color?: string;
+        position?: number;
+        isClosedState?: boolean;
+        isTriageState?: boolean;
+        isDefault?: boolean;
+      }
+    ): Promise<IssueStage> => {
+      return this.request('PATCH', `/api/repos/${owner}/${repo}/stages/${key}`, data);
+    },
+
+    /**
+     * Delete a stage
+     */
+    delete: async (owner: string, repo: string, key: string): Promise<void> => {
+      return this.request('DELETE', `/api/repos/${owner}/${repo}/stages/${key}`);
+    },
+
+    /**
+     * Reorder stages
+     */
+    reorder: async (
+      owner: string,
+      repo: string,
+      stageIds: string[]
+    ): Promise<IssueStage[]> => {
+      return this.request('POST', `/api/repos/${owner}/${repo}/stages/reorder`, { stageIds });
+    },
+
+    /**
+     * Initialize default stages for a repository
+     */
+    init: async (owner: string, repo: string): Promise<IssueStage[]> => {
+      return this.request('POST', `/api/repos/${owner}/${repo}/stages/init`);
+    },
   };
 
   // ============================================================================
@@ -1522,6 +1627,23 @@ export interface Cycle {
   description?: string;
   startDate: string;
   endDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IssueStage {
+  id: string;
+  repoId: string;
+  key: string;
+  name: string;
+  description?: string;
+  icon: string;
+  color: string;
+  position: number;
+  isClosedState: boolean;
+  isTriageState: boolean;
+  isDefault: boolean;
+  isSystem: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/db/migrations/0008_issue_stages.sql
+++ b/src/db/migrations/0008_issue_stages.sql
@@ -1,0 +1,46 @@
+-- Issue Stages table for custom workflow stages per repository
+-- Allows users to define their own stages beyond the default Linear-style ones
+CREATE TABLE "issue_stages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"repo_id" uuid NOT NULL,
+	"key" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"icon" text DEFAULT '○' NOT NULL,
+	"color" text DEFAULT '6b7280' NOT NULL,
+	"position" integer DEFAULT 0 NOT NULL,
+	"is_closed_state" boolean DEFAULT false NOT NULL,
+	"is_triage_state" boolean DEFAULT false NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"is_system" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "issue_stages_repo_id_key_unique" UNIQUE("repo_id","key")
+);
+--> statement-breakpoint
+ALTER TABLE "issue_stages" ADD CONSTRAINT "issue_stages_repo_id_repositories_id_fk" FOREIGN KEY ("repo_id") REFERENCES "public"."repositories"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+-- Create default stages for existing repositories
+INSERT INTO "issue_stages" ("repo_id", "key", "name", "icon", "color", "position", "is_closed_state", "is_triage_state", "is_default", "is_system")
+SELECT 
+  r.id,
+  stage.key,
+  stage.name,
+  stage.icon,
+  stage.color,
+  stage.position,
+  stage.is_closed_state,
+  stage.is_triage_state,
+  stage.is_default,
+  true
+FROM repositories r
+CROSS JOIN (
+  VALUES 
+    ('triage', 'Triage', '◇', '9ca3af', 0, false, true, false),
+    ('backlog', 'Backlog', '○', '6b7280', 1, false, false, true),
+    ('todo', 'Todo', '◔', 'f59e0b', 2, false, false, false),
+    ('in_progress', 'In Progress', '◑', '3b82f6', 3, false, false, false),
+    ('in_review', 'In Review', '◕', '8b5cf6', 4, false, false, false),
+    ('done', 'Done', '●', '22c55e', 5, true, false, false),
+    ('canceled', 'Canceled', '⊘', 'ef4444', 6, true, false, false)
+) AS stage(key, name, icon, color, position, is_closed_state, is_triage_state, is_default);

--- a/src/db/migrations/0009_issue_stage_id.sql
+++ b/src/db/migrations/0009_issue_stage_id.sql
@@ -1,0 +1,14 @@
+-- Add stage_id column to issues table for custom stage support
+ALTER TABLE "issues" ADD COLUMN "stage_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "issues" ADD CONSTRAINT "issues_stage_id_issue_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."issue_stages"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+-- Create index for efficient lookups
+CREATE INDEX "issues_stage_id_idx" ON "issues" ("stage_id");
+--> statement-breakpoint
+-- Update existing issues to link to their corresponding stages based on status
+UPDATE "issues" i
+SET "stage_id" = s.id
+FROM "issue_stages" s
+WHERE i.repo_id = s.repo_id 
+  AND i.status::text = s.key;

--- a/src/db/models/index.ts
+++ b/src/db/models/index.ts
@@ -47,6 +47,9 @@ export {
 // Issue relations model
 export { issueRelationModel } from './issue-relations';
 
+// Issue stages model (custom workflow stages)
+export { issueStageModel, DEFAULT_STAGES } from './issue-stage';
+
 // Issue activity model
 export { issueActivityModel, type ActivityAction } from './issue-activity';
 

--- a/src/db/models/issue-stage.ts
+++ b/src/db/models/issue-stage.ts
@@ -1,0 +1,353 @@
+import { eq, and, asc, desc } from 'drizzle-orm';
+import { getDb } from '../index';
+import {
+  issueStages,
+  type IssueStage,
+  type NewIssueStage,
+} from '../schema';
+
+/**
+ * Default stages that are created for each new repository
+ * These match the existing hardcoded stages for backward compatibility
+ */
+export const DEFAULT_STAGES: Omit<NewIssueStage, 'repoId'>[] = [
+  {
+    key: 'triage',
+    name: 'Triage',
+    description: 'New issues that need to be reviewed and categorized',
+    icon: '◇',
+    color: '9ca3af',
+    position: 0,
+    isClosedState: false,
+    isTriageState: true,
+    isDefault: false,
+    isSystem: true,
+  },
+  {
+    key: 'backlog',
+    name: 'Backlog',
+    description: 'Issues that have been accepted but not yet scheduled',
+    icon: '○',
+    color: '6b7280',
+    position: 1,
+    isClosedState: false,
+    isTriageState: false,
+    isDefault: true,
+    isSystem: true,
+  },
+  {
+    key: 'todo',
+    name: 'Todo',
+    description: 'Issues ready to be worked on',
+    icon: '◔',
+    color: 'f59e0b',
+    position: 2,
+    isClosedState: false,
+    isTriageState: false,
+    isDefault: false,
+    isSystem: true,
+  },
+  {
+    key: 'in_progress',
+    name: 'In Progress',
+    description: 'Issues currently being worked on',
+    icon: '◑',
+    color: '3b82f6',
+    position: 3,
+    isClosedState: false,
+    isTriageState: false,
+    isDefault: false,
+    isSystem: true,
+  },
+  {
+    key: 'in_review',
+    name: 'In Review',
+    description: 'Issues pending review',
+    icon: '◕',
+    color: '8b5cf6',
+    position: 4,
+    isClosedState: false,
+    isTriageState: false,
+    isDefault: false,
+    isSystem: true,
+  },
+  {
+    key: 'done',
+    name: 'Done',
+    description: 'Completed issues',
+    icon: '●',
+    color: '22c55e',
+    position: 5,
+    isClosedState: true,
+    isTriageState: false,
+    isDefault: false,
+    isSystem: true,
+  },
+  {
+    key: 'canceled',
+    name: 'Canceled',
+    description: 'Issues that will not be worked on',
+    icon: '⊘',
+    color: 'ef4444',
+    position: 6,
+    isClosedState: true,
+    isTriageState: false,
+    isDefault: false,
+    isSystem: true,
+  },
+];
+
+export const issueStageModel = {
+  /**
+   * Find a stage by ID
+   */
+  async findById(id: string): Promise<IssueStage | undefined> {
+    const db = getDb();
+    const [stage] = await db
+      .select()
+      .from(issueStages)
+      .where(eq(issueStages.id, id));
+    return stage;
+  },
+
+  /**
+   * Find a stage by key within a repository
+   */
+  async findByKey(repoId: string, key: string): Promise<IssueStage | undefined> {
+    const db = getDb();
+    const [stage] = await db
+      .select()
+      .from(issueStages)
+      .where(and(eq(issueStages.repoId, repoId), eq(issueStages.key, key)));
+    return stage;
+  },
+
+  /**
+   * List all stages for a repository, ordered by position
+   */
+  async listByRepo(repoId: string): Promise<IssueStage[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(issueStages)
+      .where(eq(issueStages.repoId, repoId))
+      .orderBy(asc(issueStages.position));
+  },
+
+  /**
+   * Get the default stage for a repository (used for new issues)
+   */
+  async getDefault(repoId: string): Promise<IssueStage | undefined> {
+    const db = getDb();
+    const [stage] = await db
+      .select()
+      .from(issueStages)
+      .where(and(eq(issueStages.repoId, repoId), eq(issueStages.isDefault, true)));
+    
+    // If no default is set, fall back to first non-triage, non-closed stage
+    if (!stage) {
+      const [fallback] = await db
+        .select()
+        .from(issueStages)
+        .where(
+          and(
+            eq(issueStages.repoId, repoId),
+            eq(issueStages.isTriageState, false),
+            eq(issueStages.isClosedState, false)
+          )
+        )
+        .orderBy(asc(issueStages.position))
+        .limit(1);
+      return fallback;
+    }
+    
+    return stage;
+  },
+
+  /**
+   * Get the triage stage for a repository
+   */
+  async getTriage(repoId: string): Promise<IssueStage | undefined> {
+    const db = getDb();
+    const [stage] = await db
+      .select()
+      .from(issueStages)
+      .where(and(eq(issueStages.repoId, repoId), eq(issueStages.isTriageState, true)));
+    return stage;
+  },
+
+  /**
+   * Get closed stages for a repository
+   */
+  async getClosedStages(repoId: string): Promise<IssueStage[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(issueStages)
+      .where(and(eq(issueStages.repoId, repoId), eq(issueStages.isClosedState, true)))
+      .orderBy(asc(issueStages.position));
+  },
+
+  /**
+   * Get open (active) stages for a repository
+   */
+  async getOpenStages(repoId: string): Promise<IssueStage[]> {
+    const db = getDb();
+    return db
+      .select()
+      .from(issueStages)
+      .where(and(eq(issueStages.repoId, repoId), eq(issueStages.isClosedState, false)))
+      .orderBy(asc(issueStages.position));
+  },
+
+  /**
+   * Create a new stage
+   */
+  async create(data: NewIssueStage): Promise<IssueStage> {
+    const db = getDb();
+    
+    // Get the next position if not specified
+    if (data.position === undefined || data.position === null) {
+      const stages = await this.listByRepo(data.repoId);
+      data.position = stages.length;
+    }
+
+    // Ensure only one default stage
+    if (data.isDefault) {
+      await db
+        .update(issueStages)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(eq(issueStages.repoId, data.repoId));
+    }
+
+    const [stage] = await db
+      .insert(issueStages)
+      .values(data)
+      .returning();
+    return stage;
+  },
+
+  /**
+   * Update a stage
+   */
+  async update(
+    id: string,
+    data: Partial<Omit<NewIssueStage, 'id' | 'repoId' | 'createdAt'>>
+  ): Promise<IssueStage | undefined> {
+    const db = getDb();
+    
+    const stage = await this.findById(id);
+    if (!stage) return undefined;
+
+    // Ensure only one default stage
+    if (data.isDefault) {
+      await db
+        .update(issueStages)
+        .set({ isDefault: false, updatedAt: new Date() })
+        .where(eq(issueStages.repoId, stage.repoId));
+    }
+
+    const [updated] = await db
+      .update(issueStages)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(issueStages.id, id))
+      .returning();
+    return updated;
+  },
+
+  /**
+   * Delete a stage (only non-system stages can be deleted)
+   * Returns false if the stage is a system stage
+   */
+  async delete(id: string): Promise<boolean> {
+    const db = getDb();
+    
+    const stage = await this.findById(id);
+    if (!stage || stage.isSystem) {
+      return false;
+    }
+
+    const result = await db
+      .delete(issueStages)
+      .where(eq(issueStages.id, id))
+      .returning();
+    return result.length > 0;
+  },
+
+  /**
+   * Reorder stages within a repository
+   * Takes an array of stage IDs in the new order
+   */
+  async reorder(repoId: string, stageIds: string[]): Promise<IssueStage[]> {
+    const db = getDb();
+    
+    // Update positions for each stage
+    for (let i = 0; i < stageIds.length; i++) {
+      await db
+        .update(issueStages)
+        .set({ position: i, updatedAt: new Date() })
+        .where(and(eq(issueStages.id, stageIds[i]), eq(issueStages.repoId, repoId)));
+    }
+
+    return this.listByRepo(repoId);
+  },
+
+  /**
+   * Create default stages for a new repository
+   */
+  async createDefaultStages(repoId: string): Promise<IssueStage[]> {
+    const db = getDb();
+    
+    const created: IssueStage[] = [];
+    for (const stageData of DEFAULT_STAGES) {
+      const [stage] = await db
+        .insert(issueStages)
+        .values({ ...stageData, repoId })
+        .returning();
+      created.push(stage);
+    }
+
+    return created;
+  },
+
+  /**
+   * Check if a repository has custom stages set up
+   */
+  async hasStages(repoId: string): Promise<boolean> {
+    const db = getDb();
+    const stages = await db
+      .select({ id: issueStages.id })
+      .from(issueStages)
+      .where(eq(issueStages.repoId, repoId))
+      .limit(1);
+    return stages.length > 0;
+  },
+
+  /**
+   * Get stage configuration as a map (for efficient lookups)
+   */
+  async getStageMap(repoId: string): Promise<Map<string, IssueStage>> {
+    const stages = await this.listByRepo(repoId);
+    const map = new Map<string, IssueStage>();
+    for (const stage of stages) {
+      map.set(stage.key, stage);
+    }
+    return map;
+  },
+
+  /**
+   * Validate if a stage key is valid for a repository
+   */
+  async isValidStage(repoId: string, stageKey: string): Promise<boolean> {
+    const stage = await this.findByKey(repoId, stageKey);
+    return stage !== undefined;
+  },
+
+  /**
+   * Get the next position for a new stage
+   */
+  async getNextPosition(repoId: string): Promise<number> {
+    const stages = await this.listByRepo(repoId);
+    return stages.length;
+  },
+};

--- a/src/db/models/repository.ts
+++ b/src/db/models/repository.ts
@@ -14,6 +14,7 @@ import {
   type Watch,
 } from '../schema';
 import { user } from '../auth-schema';
+import { issueStageModel } from './issue-stage';
 
 // Owner type for better-auth user table
 type Owner = {
@@ -175,10 +176,20 @@ export const repoModel = {
 
   /**
    * Create a new repository
+   * Also creates default issue stages for the repository
    */
   async create(data: NewRepository): Promise<Repository> {
     const db = getDb();
     const [repo] = await db.insert(repositories).values(data).returning();
+    
+    // Create default issue stages for the new repository
+    try {
+      await issueStageModel.createDefaultStages(repo.id);
+    } catch (error) {
+      // Log but don't fail repo creation if stages fail
+      console.error('Failed to create default stages for repo:', repo.id, error);
+    }
+    
     return repo;
   },
 


### PR DESCRIPTION
## Summary

- Add custom issue stages feature allowing users to define their own workflow stages per repository
- Implement full database schema, API, CLI, and UI support for stage management
- Auto-create default stages (triage, backlog, todo, in_progress, in_review, done, canceled) for new repositories

## Changes

### Database
- New `issue_stages` table with migrations (`0008_issue_stages.sql`, `0009_issue_stage_id.sql`)
- Added `stageId` foreign key to issues table
- Created `issueStageModel` with CRUD operations

### API
- Stage management endpoints: list, create, get, update, delete, reorder
- Issue stage update endpoint
- Board view endpoint (issues grouped by stage)

### CLI
- `wit issue stages` - List, add, remove, update stages
- `wit issue stage <number> <stage>` - Move issue to a stage

### UI
- Dynamic stage columns in issue board
- Stage management modal for creating/editing/reordering stages
- Color and icon customization

### Core
- Updated `IssueManager` for local-first stage support
- Auto-create default stages on repository creation